### PR TITLE
add requestId in log message; add log level;

### DIFF
--- a/admin-server.go
+++ b/admin-server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	router "github.com/gorilla/mux"
-	api "github.com/journeymidnight/yig/api"
+	"github.com/journeymidnight/yig/api"
 	"github.com/journeymidnight/yig/helper"
 	"github.com/journeymidnight/yig/iam"
 	"github.com/journeymidnight/yig/iam/common"
@@ -55,7 +55,7 @@ func getUsage(w http.ResponseWriter, r *http.Request) {
 	claims := r.Context().Value("claims").(jwt.MapClaims)
 	bucketName := claims["bucket"].(string)
 
-	usage, err := adminServer.Yig.MetaStorage.GetUsage(bucketName, r.Context())
+	usage, err := adminServer.Yig.MetaStorage.GetUsage(r.Context(), bucketName)
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
@@ -70,7 +70,7 @@ func getBucketInfo(w http.ResponseWriter, r *http.Request) {
 	bucketName := claims["bucket"].(string)
 
 	helper.Debugln("[", api.RequestIdFromContext(r.Context()), "]", "bucketName:", bucketName)
-	bucket, err := adminServer.Yig.MetaStorage.GetBucketInfo(bucketName, r.Context())
+	bucket, err := adminServer.Yig.MetaStorage.GetBucketInfo(r.Context(), bucketName)
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
@@ -85,7 +85,7 @@ func getUserInfo(w http.ResponseWriter, r *http.Request) {
 	claims := r.Context().Value("claims").(jwt.MapClaims)
 	uid := claims["uid"].(string)
 
-	buckets, err := adminServer.Yig.MetaStorage.GetUserInfo(uid, r.Context())
+	buckets, err := adminServer.Yig.MetaStorage.GetUserInfo(r.Context(), uid)
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
@@ -111,7 +111,7 @@ func getObjectInfo(w http.ResponseWriter, r *http.Request) {
 	bucketName := claims["bucket"].(string)
 	objectName := claims["object"].(string)
 
-	object, err := adminServer.Yig.MetaStorage.GetObject(bucketName, objectName, true, r.Context())
+	object, err := adminServer.Yig.MetaStorage.GetObject(r.Context(), bucketName, objectName, true)
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return

--- a/admin-server.go
+++ b/admin-server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	router "github.com/gorilla/mux"
-	"github.com/journeymidnight/yig/api"
+	api "github.com/journeymidnight/yig/api"
 	"github.com/journeymidnight/yig/helper"
 	"github.com/journeymidnight/yig/iam"
 	"github.com/journeymidnight/yig/iam/common"
@@ -55,7 +55,7 @@ func getUsage(w http.ResponseWriter, r *http.Request) {
 	claims := r.Context().Value("claims").(jwt.MapClaims)
 	bucketName := claims["bucket"].(string)
 
-	usage, err := adminServer.Yig.MetaStorage.GetUsage(bucketName)
+	usage, err := adminServer.Yig.MetaStorage.GetUsage(bucketName, r.Context())
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
@@ -69,8 +69,8 @@ func getBucketInfo(w http.ResponseWriter, r *http.Request) {
 	claims := r.Context().Value("claims").(jwt.MapClaims)
 	bucketName := claims["bucket"].(string)
 
-	helper.Debugln("bucketName:", bucketName)
-	bucket, err := adminServer.Yig.MetaStorage.GetBucketInfo(bucketName)
+	helper.Debugln("[", api.RequestIdFromContext(r.Context()), "]", "bucketName:", bucketName)
+	bucket, err := adminServer.Yig.MetaStorage.GetBucketInfo(bucketName, r.Context())
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
@@ -85,12 +85,12 @@ func getUserInfo(w http.ResponseWriter, r *http.Request) {
 	claims := r.Context().Value("claims").(jwt.MapClaims)
 	uid := claims["uid"].(string)
 
-	buckets, err := adminServer.Yig.MetaStorage.GetUserInfo(uid)
+	buckets, err := adminServer.Yig.MetaStorage.GetUserInfo(uid, r.Context())
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
 	}
-	helper.Debugln("enter getUserInfo", uid, buckets)
+	helper.Debugln("[", api.RequestIdFromContext(r.Context()), "]", "enter getUserInfo", uid, buckets)
 
 	var keys []common.Credential
 	if helper.CONFIG.DebugMode == false {
@@ -106,12 +106,12 @@ func getUserInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func getObjectInfo(w http.ResponseWriter, r *http.Request) {
-	helper.Debugln("enter getObjectInfo")
+	helper.Debugln("[", api.RequestIdFromContext(r.Context()), "]", "enter getObjectInfo")
 	claims := r.Context().Value("claims").(jwt.MapClaims)
 	bucketName := claims["bucket"].(string)
 	objectName := claims["object"].(string)
 
-	object, err := adminServer.Yig.MetaStorage.GetObject(bucketName, objectName, true)
+	object, err := adminServer.Yig.MetaStorage.GetObject(bucketName, objectName, true, r.Context())
 	if err != nil {
 		api.WriteErrorResponse(w, r, err)
 		return
@@ -122,7 +122,7 @@ func getObjectInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func getCacheHitRatio(w http.ResponseWriter, r *http.Request) {
-	helper.Debugln("enter getCacheHitRatio")
+	helper.Debugln("[", api.RequestIdFromContext(r.Context()), "]", "enter getCacheHitRatio")
 
 	rate := adminServer.Yig.MetaStorage.Cache.GetCacheHitRatio()
 	b, _ := json.Marshal(cacheJson{HitRate: rate})

--- a/api/api-resources.go
+++ b/api/api-resources.go
@@ -17,16 +17,18 @@
 package api
 
 import (
+	"context"
 	"net/url"
 	"strconv"
+
+	"unicode/utf8"
 
 	. "github.com/journeymidnight/yig/api/datatype"
 	. "github.com/journeymidnight/yig/error"
 	"github.com/journeymidnight/yig/helper"
-	"unicode/utf8"
 )
 
-func parseListObjectsQuery(query url.Values) (request ListObjectsRequest, err error) {
+func parseListObjectsQuery(query url.Values, ctx context.Context) (request ListObjectsRequest, err error) {
 	if query.Get("list-type") == "2" {
 		request.Version = 2
 		request.ContinuationToken = query.Get("continuation-token")
@@ -60,7 +62,7 @@ func parseListObjectsQuery(query url.Values) (request ListObjectsRequest, err er
 	} else {
 		request.MaxKeys, err = strconv.Atoi(query.Get("max-keys"))
 		if err != nil {
-			helper.Debugln("Error parsing max-keys:", err)
+			helper.Debugln("[", RequestIdFromContext(ctx), "]", "Error parsing max-keys:", err)
 			return request, ErrInvalidMaxKeys
 		}
 		if request.MaxKeys > MaxObjectList || request.MaxKeys < 1 {

--- a/api/api-resources.go
+++ b/api/api-resources.go
@@ -28,7 +28,7 @@ import (
 	"github.com/journeymidnight/yig/helper"
 )
 
-func parseListObjectsQuery(query url.Values, ctx context.Context) (request ListObjectsRequest, err error) {
+func parseListObjectsQuery(ctx context.Context, query url.Values) (request ListObjectsRequest, err error) {
 	if query.Get("list-type") == "2" {
 		request.Version = 2
 		request.ContinuationToken = query.Get("continuation-token")

--- a/api/api-response.go
+++ b/api/api-response.go
@@ -224,16 +224,16 @@ func WriteSuccessNoContent(w http.ResponseWriter) {
 
 // writeErrorResponse write error headers
 func WriteErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
-	WriteErrorResponseHeaders(w, err, r)
+	WriteErrorResponseHeaders(w, r, err)
 	WriteErrorResponseNoHeader(w, r, err, r.URL.Path)
 }
 
 func WriteErrorResponseWithResource(w http.ResponseWriter, r *http.Request, err error, resource string) {
-	WriteErrorResponseHeaders(w, err, r)
+	WriteErrorResponseHeaders(w, r, err)
 	WriteErrorResponseNoHeader(w, r, err, resource)
 }
 
-func WriteErrorResponseHeaders(w http.ResponseWriter, err error, r *http.Request) {
+func WriteErrorResponseHeaders(w http.ResponseWriter, r *http.Request, err error) {
 	var status int
 	apiErrorCode, ok := err.(ApiError)
 	if ok {

--- a/api/api-response.go
+++ b/api/api-response.go
@@ -224,16 +224,16 @@ func WriteSuccessNoContent(w http.ResponseWriter) {
 
 // writeErrorResponse write error headers
 func WriteErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
-	WriteErrorResponseHeaders(w, err)
+	WriteErrorResponseHeaders(w, err, r)
 	WriteErrorResponseNoHeader(w, r, err, r.URL.Path)
 }
 
 func WriteErrorResponseWithResource(w http.ResponseWriter, r *http.Request, err error, resource string) {
-	WriteErrorResponseHeaders(w, err)
+	WriteErrorResponseHeaders(w, err, r)
 	WriteErrorResponseNoHeader(w, r, err, resource)
 }
 
-func WriteErrorResponseHeaders(w http.ResponseWriter, err error) {
+func WriteErrorResponseHeaders(w http.ResponseWriter, err error, r *http.Request) {
 	var status int
 	apiErrorCode, ok := err.(ApiError)
 	if ok {
@@ -241,7 +241,7 @@ func WriteErrorResponseHeaders(w http.ResponseWriter, err error) {
 	} else {
 		status = http.StatusInternalServerError
 	}
-	helper.Logger.Println(5, "Response status code:", status, "err:", err)
+	helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "Response status code:", status, "err:", err)
 
 	//ResponseRecorder
 	w.(*ResponseRecorder).status = status
@@ -266,7 +266,7 @@ func WriteErrorResponseNoHeader(w http.ResponseWriter, req *http.Request, err er
 		errorResponse.Message = "We encountered an internal error, please try again."
 	}
 	errorResponse.Resource = resource
-	errorResponse.RequestId = requestIdFromContext(req.Context())
+	errorResponse.RequestId = RequestIdFromContext(req.Context())
 	errorResponse.HostId = helper.CONFIG.InstanceId
 
 	encodedErrorResponse := EncodeResponse(errorResponse)

--- a/api/auth-handler.go
+++ b/api/auth-handler.go
@@ -45,7 +45,7 @@ func checkRequestAuth(api ObjectAPIHandlers, r *http.Request, action policy.Acti
 }
 
 func IsBucketPolicyAllowed(c common.Credential, api ObjectAPIHandlers, r *http.Request, action policy.Action, bucketName, objectName string) (common.Credential, error) {
-	bucket, err := api.ObjectAPI.GetBucket(bucketName, r.Context())
+	bucket, err := api.ObjectAPI.GetBucket(r.Context(), bucketName)
 	if err != nil {
 		helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "GetBucket", bucketName, "err:", err)
 		return c, err

--- a/api/auth-handler.go
+++ b/api/auth-handler.go
@@ -23,16 +23,16 @@ func checkRequestAuth(api ObjectAPIHandlers, r *http.Request, action policy.Acti
 	authType := signature.GetRequestAuthType(r)
 	switch authType {
 	case signature.AuthTypeUnknown:
-		helper.Logger.Println(5, "ErrAccessDenied: AuthTypeUnknown")
+		helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "ErrAccessDenied: AuthTypeUnknown")
 		return c, ErrAccessDenied
 	case signature.AuthTypeSignedV4, signature.AuthTypePresignedV4,
 		signature.AuthTypePresignedV2, signature.AuthTypeSignedV2:
-		helper.Logger.Println(5, "AuthTypeSigned:", authType)
+		helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "AuthTypeSigned:", authType)
 		if c, err := signature.IsReqAuthenticated(r); err != nil {
-			helper.Logger.Println(5, "ErrAccessDenied: IsReqAuthenticated return false:", err)
+			helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "ErrAccessDenied: IsReqAuthenticated return false:", err)
 			return c, err
 		} else {
-			helper.Logger.Println(5, "Credential:", c)
+			helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "Credential:", c)
 			// check bucket policy
 			c, err = IsBucketPolicyAllowed(c, api, r, action, bucketName, objectName)
 			return c, err
@@ -45,16 +45,16 @@ func checkRequestAuth(api ObjectAPIHandlers, r *http.Request, action policy.Acti
 }
 
 func IsBucketPolicyAllowed(c common.Credential, api ObjectAPIHandlers, r *http.Request, action policy.Action, bucketName, objectName string) (common.Credential, error) {
-	bucket, err := api.ObjectAPI.GetBucket(bucketName)
+	bucket, err := api.ObjectAPI.GetBucket(bucketName, r.Context())
 	if err != nil {
-		helper.Logger.Println(5, "GetBucket", bucketName, "err:", err)
+		helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "GetBucket", bucketName, "err:", err)
 		return c, err
 	}
 	if bucket.OwnerId == c.UserId {
 		return c, nil
 	}
-	helper.Logger.Println(5, "bucket.OwnerId:", bucket.OwnerId, "not equals c.UserId:", c.UserId)
-	helper.Debugln("GetBucketPolicy:", bucket.Policy)
+	helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "bucket.OwnerId:", bucket.OwnerId, "not equals c.UserId:", c.UserId)
+	helper.Debugln("[", RequestIdFromContext(r.Context()), "]", "GetBucketPolicy:", bucket.Policy)
 	policyResult := bucket.Policy.IsAllowed(policy.Args{
 		AccountName:     c.UserId,
 		Action:          action,
@@ -65,10 +65,12 @@ func IsBucketPolicyAllowed(c common.Credential, api ObjectAPIHandlers, r *http.R
 	})
 	if policyResult == policy.PolicyAllow {
 		c.AllowOtherUserAccess = true
-		helper.Debugln("Allow", c.UserId, "access", bucketName, "with", action, objectName)
+		helper.Debugln("[", RequestIdFromContext(r.Context()), "]",
+			"Allow", c.UserId, "access", bucketName, "with", action, objectName)
 		return c, nil
 	} else if policyResult == policy.PolicyDeny {
-		helper.Debugln("ErrAccessDenied: NotAllow", c.UserId, "access", bucketName, "with", action, objectName)
+		helper.Debugln("[", RequestIdFromContext(r.Context()), "]",
+			"ErrAccessDenied: NotAllow", c.UserId, "access", bucketName, "with", action, objectName)
 		return c, ErrAccessDenied
 	} else {
 		return c, nil

--- a/api/bucket-handlers.go
+++ b/api/bucket-handlers.go
@@ -56,7 +56,7 @@ func (api ObjectAPIHandlers) GetBucketLocationHandler(w http.ResponseWriter, r *
 		}
 	}
 
-	if _, err = api.ObjectAPI.GetBucketInfo(bucketName, credential, r.Context()); err != nil {
+	if _, err = api.ObjectAPI.GetBucketInfo(r.Context(), bucketName, credential); err != nil {
 		helper.ErrorIf(err, "Unable to fetch bucket info.")
 		WriteErrorResponse(w, r, err)
 		return
@@ -104,7 +104,7 @@ func (api ObjectAPIHandlers) ListMultipartUploadsHandler(w http.ResponseWriter, 
 		return
 	}
 
-	listMultipartsResponse, err := api.ObjectAPI.ListMultipartUploads(credential, bucketName, request, r.Context())
+	listMultipartsResponse, err := api.ObjectAPI.ListMultipartUploads(r.Context(), credential, bucketName, request)
 	if err != nil {
 		helper.ErrorIf(err, "Unable to list multipart uploads.")
 		WriteErrorResponse(w, r, err)
@@ -142,13 +142,13 @@ func (api ObjectAPIHandlers) ListObjectsHandler(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	request, err := parseListObjectsQuery(r.URL.Query(), r.Context())
+	request, err := parseListObjectsQuery(r.Context(), r.URL.Query())
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
 
-	listObjectsInfo, err := api.ObjectAPI.ListObjects(credential, bucketName, request, r.Context())
+	listObjectsInfo, err := api.ObjectAPI.ListObjects(r.Context(), credential, bucketName, request)
 	if err != nil {
 		helper.ErrorIf(err, "Unable to list objects.")
 		WriteErrorResponse(w, r, err)
@@ -184,14 +184,14 @@ func (api ObjectAPIHandlers) ListVersionedObjectsHandler(w http.ResponseWriter, 
 		}
 	}
 
-	request, err := parseListObjectsQuery(r.URL.Query(), r.Context())
+	request, err := parseListObjectsQuery(r.Context(), r.URL.Query())
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
 	request.Versioned = true
 
-	listObjectsInfo, err := api.ObjectAPI.ListVersionedObjects(credential, bucketName, request, r.Context())
+	listObjectsInfo, err := api.ObjectAPI.ListVersionedObjects(r.Context(), credential, bucketName, request)
 	if err != nil {
 		helper.ErrorIf(err, "Unable to list objects.")
 		WriteErrorResponse(w, r, err)
@@ -219,7 +219,7 @@ func (api ObjectAPIHandlers) ListBucketsHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	bucketsInfo, err := api.ObjectAPI.ListBuckets(credential, r.Context())
+	bucketsInfo, err := api.ObjectAPI.ListBuckets(r.Context(), credential)
 	if err == nil {
 		// generate response
 		response := GenerateListBucketsResponse(bucketsInfo, credential)
@@ -293,8 +293,8 @@ func (api ObjectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 	var deletedObjects []ObjectIdentifier
 	// Loop through all the objects and delete them sequentially.
 	for _, object := range deleteObjects.Objects {
-		result, err := api.ObjectAPI.DeleteObject(bucket, object.ObjectName,
-			object.VersionId, credential, r.Context())
+		result, err := api.ObjectAPI.DeleteObject(r.Context(), bucket, object.ObjectName,
+			object.VersionId, credential)
 		if err == nil {
 			deletedObjects = append(deletedObjects, ObjectIdentifier{
 				ObjectName:   object.ObjectName,
@@ -371,7 +371,7 @@ func (api ObjectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 	//	}
 
 	// Make bucket.
-	err = api.ObjectAPI.MakeBucket(bucketName, acl, credential, r.Context())
+	err = api.ObjectAPI.MakeBucket(r.Context(), bucketName, acl, credential)
 	if err != nil {
 		helper.ErrorIf(err, "Unable to create bucket "+bucketName)
 		WriteErrorResponse(w, r, err)
@@ -408,7 +408,7 @@ func (api ObjectAPIHandlers) PutBucketLifeCycleHandler(w http.ResponseWriter, r 
 	}
 
 	helper.Debugln("[", RequestIdFromContext(r.Context()), "]", "Set LC:", lc)
-	err = api.ObjectAPI.SetBucketLc(bucket, lc, credential, r.Context())
+	err = api.ObjectAPI.SetBucketLc(r.Context(), bucket, lc, credential)
 	if err != nil {
 		helper.ErrorIf(err, "Unable to set LC for bucket.")
 		WriteErrorResponse(w, r, err)
@@ -438,7 +438,7 @@ func (api ObjectAPIHandlers) GetBucketLifeCycleHandler(w http.ResponseWriter, r 
 		}
 	}
 
-	lc, err := api.ObjectAPI.GetBucketLc(bucketName, credential, r.Context())
+	lc, err := api.ObjectAPI.GetBucketLc(r.Context(), bucketName, credential)
 	if err != nil {
 		helper.ErrorIf(err, "Failed to get bucket acl policy for bucket", bucketName)
 		WriteErrorResponse(w, r, err)
@@ -468,7 +468,7 @@ func (api ObjectAPIHandlers) DelBucketLifeCycleHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	err = api.ObjectAPI.DelBucketLc(bucketName, credential, r.Context())
+	err = api.ObjectAPI.DelBucketLc(r.Context(), bucketName, credential)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
@@ -512,7 +512,7 @@ func (api ObjectAPIHandlers) PutBucketAclHandler(w http.ResponseWriter, r *http.
 		}
 	}
 
-	err = api.ObjectAPI.SetBucketAcl(bucket, policy, acl, credential, r.Context())
+	err = api.ObjectAPI.SetBucketAcl(r.Context(), bucket, policy, acl, credential)
 	if err != nil {
 		helper.ErrorIf(err, "Unable to set ACL for bucket.")
 		WriteErrorResponse(w, r, err)
@@ -542,7 +542,7 @@ func (api ObjectAPIHandlers) GetBucketAclHandler(w http.ResponseWriter, r *http.
 		}
 	}
 
-	policy, err := api.ObjectAPI.GetBucketAcl(bucketName, credential, r.Context())
+	policy, err := api.ObjectAPI.GetBucketAcl(r.Context(), bucketName, credential)
 	if err != nil {
 		helper.ErrorIf(err, "Failed to get bucket acl policy for bucket", bucketName)
 		WriteErrorResponse(w, r, err)
@@ -591,12 +591,12 @@ func (api ObjectAPIHandlers) PutBucketCorsHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	cors, err := CorsFromXml(corsBuffer, r.Context())
+	cors, err := CorsFromXml(r.Context(), corsBuffer)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
-	err = api.ObjectAPI.SetBucketCors(bucketName, cors, credential, r.Context())
+	err = api.ObjectAPI.SetBucketCors(r.Context(), bucketName, cors, credential)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
@@ -615,7 +615,7 @@ func (api ObjectAPIHandlers) DeleteBucketCorsHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	err = api.ObjectAPI.DeleteBucketCors(bucketName, credential, r.Context())
+	err = api.ObjectAPI.DeleteBucketCors(r.Context(), bucketName, credential)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
@@ -634,7 +634,7 @@ func (api ObjectAPIHandlers) GetBucketCorsHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	cors, err := api.ObjectAPI.GetBucketCors(bucketName, credential, r.Context())
+	cors, err := api.ObjectAPI.GetBucketCors(r.Context(), bucketName, credential)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
@@ -662,7 +662,7 @@ func (api ObjectAPIHandlers) GetBucketVersioningHandler(w http.ResponseWriter, r
 		return
 	}
 
-	versioning, err := api.ObjectAPI.GetBucketVersioning(bucketName, credential, r.Context())
+	versioning, err := api.ObjectAPI.GetBucketVersioning(r.Context(), bucketName, credential)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
@@ -716,7 +716,7 @@ func (api ObjectAPIHandlers) PutBucketVersioningHandler(w http.ResponseWriter, r
 		WriteErrorResponse(w, r, err)
 		return
 	}
-	err = api.ObjectAPI.SetBucketVersioning(bucketName, versioning, credential, r.Context())
+	err = api.ObjectAPI.SetBucketVersioning(r.Context(), bucketName, versioning, credential)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return
@@ -798,7 +798,7 @@ func (api ObjectAPIHandlers) HeadBucketHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	if _, err = api.ObjectAPI.GetBucketInfo(bucket, credential, r.Context()); err != nil {
+	if _, err = api.ObjectAPI.GetBucketInfo(r.Context(), bucket, credential); err != nil {
 		helper.ErrorIf(err, "Unable to fetch bucket info.")
 		WriteErrorResponse(w, r, err)
 		return
@@ -818,7 +818,7 @@ func (api ObjectAPIHandlers) DeleteBucketHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if err = api.ObjectAPI.DeleteBucket(bucket, credential, r.Context()); err != nil {
+	if err = api.ObjectAPI.DeleteBucket(r.Context(), bucket, credential); err != nil {
 		helper.ErrorIf(err, "Unable to delete a bucket.")
 		WriteErrorResponse(w, r, err)
 		return

--- a/api/bucket-policy-handlers.go
+++ b/api/bucket-policy-handlers.go
@@ -88,7 +88,7 @@ func (api ObjectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err = api.ObjectAPI.SetBucketPolicy(credential, bucket, *bucketPolicy, r.Context()); err != nil {
+	if err = api.ObjectAPI.SetBucketPolicy(r.Context(), credential, bucket, *bucketPolicy); err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
@@ -118,7 +118,7 @@ func (api ObjectAPIHandlers) DeleteBucketPolicyHandler(w http.ResponseWriter, r 
 		}
 	}
 
-	if err := api.ObjectAPI.DeleteBucketPolicy(credential, bucket, r.Context()); err != nil {
+	if err := api.ObjectAPI.DeleteBucketPolicy(r.Context(), credential, bucket); err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
@@ -150,7 +150,7 @@ func (api ObjectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *ht
 	}
 
 	// Read bucket access policy.
-	bucketPolicy, err := api.ObjectAPI.GetBucketPolicy(credential, bucket, r.Context())
+	bucketPolicy, err := api.ObjectAPI.GetBucketPolicy(r.Context(), credential, bucket)
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return

--- a/api/bucket-policy-handlers.go
+++ b/api/bucket-policy-handlers.go
@@ -42,7 +42,7 @@ const (
 // PutBucketPolicyHandler - This HTTP handler stores given bucket policy configuration as per
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-language-overview.html
 func (api ObjectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
-	helper.Debugln("PutBucketPolicyHandler", "enter")
+	helper.Debugln("[", RequestIdFromContext(r.Context()), "]", "PutBucketPolicyHandler", "enter")
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 
@@ -88,7 +88,7 @@ func (api ObjectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err = api.ObjectAPI.SetBucketPolicy(credential, bucket, *bucketPolicy); err != nil {
+	if err = api.ObjectAPI.SetBucketPolicy(credential, bucket, *bucketPolicy, r.Context()); err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
@@ -118,7 +118,7 @@ func (api ObjectAPIHandlers) DeleteBucketPolicyHandler(w http.ResponseWriter, r 
 		}
 	}
 
-	if err := api.ObjectAPI.DeleteBucketPolicy(credential, bucket); err != nil {
+	if err := api.ObjectAPI.DeleteBucketPolicy(credential, bucket, r.Context()); err != nil {
 		WriteErrorResponse(w, r, err)
 		return
 	}
@@ -129,7 +129,7 @@ func (api ObjectAPIHandlers) DeleteBucketPolicyHandler(w http.ResponseWriter, r 
 
 // GetBucketPolicyHandler - This HTTP handler returns bucket policy configuration.
 func (api ObjectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
-	helper.Debugln("GetBucketPolicyHandler", "enter")
+	helper.Debugln("[", RequestIdFromContext(r.Context()), "]", "GetBucketPolicyHandler", "enter")
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 	var credential common.Credential
@@ -150,7 +150,7 @@ func (api ObjectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *ht
 	}
 
 	// Read bucket access policy.
-	bucketPolicy, err := api.ObjectAPI.GetBucketPolicy(credential, bucket)
+	bucketPolicy, err := api.ObjectAPI.GetBucketPolicy(credential, bucket, r.Context())
 	if err != nil {
 		WriteErrorResponse(w, r, err)
 		return

--- a/api/datatype/acl.go
+++ b/api/datatype/acl.go
@@ -1,8 +1,9 @@
 package datatype
 
 import (
-	"encoding/xml"
 	"context"
+	"encoding/xml"
+
 	. "github.com/journeymidnight/yig/error"
 	"github.com/journeymidnight/yig/helper"
 )
@@ -80,17 +81,17 @@ type Grantee struct {
 }
 
 type AccessControlPolicyResponse struct {
-	XMLName           xml.Name `xml:"AccessControlPolicy"`
-	Xmlns             string   `xml:"xmlns,attr,omitempty"`
-	ID                string   `xml:"Owner>ID"`
-	DisplayName       string   `xml:"Owner>DisplayName"`
-	AccessControlList []GrantResponse  `xml:"AccessControlList>Grant"`
+	XMLName           xml.Name        `xml:"AccessControlPolicy"`
+	Xmlns             string          `xml:"xmlns,attr,omitempty"`
+	ID                string          `xml:"Owner>ID"`
+	DisplayName       string          `xml:"Owner>DisplayName"`
+	AccessControlList []GrantResponse `xml:"AccessControlList>Grant"`
 }
 
 type GrantResponse struct {
-	XMLName    xml.Name `xml:"Grant"`
-	Grantee    GranteeResponse  `xml:"Grantee"`
-	Permission string   `xml:"Permission"`
+	XMLName    xml.Name        `xml:"Grant"`
+	Grantee    GranteeResponse `xml:"Grantee"`
+	Permission string          `xml:"Permission"`
 }
 
 type GranteeResponse struct {
@@ -112,7 +113,7 @@ func IsValidCannedAcl(acl Acl) (err error) {
 }
 
 // the function will be deleted, because we will use AccessControlPolicy instead canned acl stored in hbase
-func GetCannedAclFromPolicy(policy AccessControlPolicy, ctx context.Context) (acl Acl, err error) {
+func GetCannedAclFromPolicy(ctx context.Context, policy AccessControlPolicy) (acl Acl, err error) {
 	aclOwner := Owner{ID: policy.ID, DisplayName: policy.DisplayName}
 	var canonUser bool
 	var group bool
@@ -121,44 +122,44 @@ func GetCannedAclFromPolicy(policy AccessControlPolicy, ctx context.Context) (ac
 		switch grant.Grantee.XsiType {
 		case ACL_TYPE_CANON_USER:
 			if grant.Grantee.ID != aclOwner.ID {
-				helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]", 
+				helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]",
 					"grant.Grantee.ID:", grant.Grantee.ID, "not equals aclOwner.ID:", aclOwner.ID)
 				return acl, ErrUnsupportedAcl
 			}
 			if grant.Permission != ACL_PERM_FULL_CONTROL {
-				helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]", 
+				helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]",
 					"grant.Permission:", grant.Permission, "not equals", ACL_PERM_FULL_CONTROL)
 				return acl, ErrUnsupportedAcl
 			}
 			canonUser = true
 		case ACL_TYPE_GROUP:
 			if grant.Grantee.URI == ACL_GROUP_TYPE_ALL_USERS {
-				helper.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", 
+				helper.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]",
 					"grant.Grantee.URI is", ACL_GROUP_TYPE_ALL_USERS)
 				if grant.Permission != ACL_PERM_READ {
-					helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]", 
+					helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]",
 						"grant.Permission:", grant.Permission, "not equals", ACL_PERM_READ)
 					return acl, ErrUnsupportedAcl
 				}
 				acl = Acl{CannedAcl: ValidCannedAcl[CANNEDACL_PUBLIC_READ]}
 				group = true
 			} else if grant.Grantee.URI == ACL_GROUP_TYPE_AUTHENTICATED_USERS {
-				helper.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", 
+				helper.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]",
 					"grant.Grantee.URI is", ACL_GROUP_TYPE_AUTHENTICATED_USERS)
 				if grant.Permission != ACL_PERM_READ {
-					helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]", 
+					helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]",
 						"grant.Permission:", grant.Permission, "not equals", ACL_PERM_FULL_CONTROL)
 					return acl, ErrUnsupportedAcl
 				}
 				acl = Acl{CannedAcl: ValidCannedAcl[CANNEDACL_AUTHENTICATED_READ]}
 				group = true
 			} else {
-				helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]", 
+				helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]",
 					"grant.Grantee.URI is invalid:", grant.Grantee.URI)
 				return acl, ErrUnsupportedAcl
 			}
 		default:
-			helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]", 
+			helper.Logger.Println(1, "[", helper.RequestIdFromContext(ctx), "]",
 				"grant.Grantee.XsiType is invalid:", grant.Grantee.XsiType)
 			return acl, ErrUnsupportedAcl
 		}

--- a/api/datatype/cors.go
+++ b/api/datatype/cors.go
@@ -1,12 +1,12 @@
 package datatype
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-	"context"
 
 	. "github.com/journeymidnight/yig/error"
 	"github.com/journeymidnight/yig/helper"
@@ -106,7 +106,7 @@ type Cors struct {
 	CorsRules []CorsRule `xml:"CORSRule"`
 }
 
-func CorsFromXml(corsBuffer []byte, ctx context.Context) (cors Cors, err error) {
+func CorsFromXml(ctx context.Context, corsBuffer []byte) (cors Cors, err error) {
 	helper.Debugln("Incoming CORS XML:", string(corsBuffer))
 	err = xml.Unmarshal(corsBuffer, &cors)
 	if err != nil {

--- a/api/datatype/cors.go
+++ b/api/datatype/cors.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"context"
 
 	. "github.com/journeymidnight/yig/error"
 	"github.com/journeymidnight/yig/helper"
@@ -105,7 +106,7 @@ type Cors struct {
 	CorsRules []CorsRule `xml:"CORSRule"`
 }
 
-func CorsFromXml(corsBuffer []byte) (cors Cors, err error) {
+func CorsFromXml(corsBuffer []byte, ctx context.Context) (cors Cors, err error) {
 	helper.Debugln("Incoming CORS XML:", string(corsBuffer))
 	err = xml.Unmarshal(corsBuffer, &cors)
 	if err != nil {

--- a/api/generic-handlers.go
+++ b/api/generic-handlers.go
@@ -187,13 +187,13 @@ func (h GenerateContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	ctx := context.WithValue(r.Context(), "RequestId", requestId)
 
 	if bucketName != "" {
-		bucketInfo, err = h.meta.GetBucket(bucketName, true, ctx)
+		bucketInfo, err = h.meta.GetBucket(ctx, bucketName, true)
 		if err != nil && err != ErrNoSuchBucket {
 			WriteErrorResponse(w, r, err)
 			return
 		}
 		if bucketInfo != nil && objectName != "" {
-			objectInfo, err = h.meta.GetObject(bucketInfo.Name, objectName, true, ctx)
+			objectInfo, err = h.meta.GetObject(ctx, bucketInfo.Name, objectName, true)
 			if err != nil && err != ErrNoSuchKey {
 				WriteErrorResponse(w, r, err)
 				return

--- a/api/generic-handlers.go
+++ b/api/generic-handlers.go
@@ -112,7 +112,7 @@ type resourceHandler struct {
 func (h resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Skip the first element which is usually '/' and split the rest.
 	bucketName, objectName := GetBucketAndObjectInfoFromRequest(r)
-	helper.Logger.Println(5, "ServeHTTP", bucketName, objectName)
+	helper.Logger.Println(5, "[", RequestIdFromContext(r.Context()), "]", "ServeHTTP", bucketName, objectName)
 	// If bucketName is present and not objectName check for bucket
 	// level resource queries.
 	if bucketName != "" && objectName == "" {
@@ -130,7 +130,7 @@ func (h resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// A put method on path "/" doesn't make sense, ignore it.
 	if r.Method == "PUT" && r.URL.Path == "/" && bucketName == "" {
-		helper.Debugln("Host:", r.Host, "Path:", r.URL.Path, "Bucket:", bucketName)
+		helper.Debugln("[", RequestIdFromContext(r.Context()), "]", "Host:", r.Host, "Path:", r.URL.Path, "Bucket:", bucketName)
 		WriteErrorResponse(w, r, ErrMethodNotAllowed)
 		return
 	}
@@ -184,16 +184,18 @@ func (h GenerateContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	var err error
 	requestId := string(helper.GenerateRandomId())
 	bucketName, objectName := GetBucketAndObjectInfoFromRequest(r)
-	helper.Logger.Println(20, "GenerateContextHandler. RequestId:", requestId, "BucketName:", bucketName, "ObjectName:", objectName)
+	helper.Logger.Println(20, "[", requestId, "]", "GenerateContextHandler. RequestId:", requestId, "BucketName:", bucketName, "ObjectName:", objectName)
+
+	ctx := context.WithValue(r.Context(), "RequestId", requestId)
 
 	if bucketName != "" {
-		bucketInfo, err = h.meta.GetBucket(bucketName, true)
+		bucketInfo, err = h.meta.GetBucket(bucketName, true, ctx)
 		if err != nil && err != ErrNoSuchBucket {
 			WriteErrorResponse(w, r, err)
 			return
 		}
 		if bucketInfo != nil && objectName != "" {
-			objectInfo, err = h.meta.GetObject(bucketInfo.Name, objectName, true)
+			objectInfo, err = h.meta.GetObject(bucketInfo.Name, objectName, true, ctx)
 			if err != nil && err != ErrNoSuchKey {
 				WriteErrorResponse(w, r, err)
 				return
@@ -201,7 +203,7 @@ func (h GenerateContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	ctx := context.WithValue(r.Context(), RequestContextKey, RequestContext{requestId, bucketInfo, objectInfo})
+	ctx = context.WithValue(ctx, RequestContextKey, RequestContext{requestId, bucketInfo, objectInfo})
 	h.handler.ServeHTTP(w, r.WithContext(ctx))
 
 }

--- a/api/log-handler.go
+++ b/api/log-handler.go
@@ -14,9 +14,9 @@ type logHandler struct {
 func (l logHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Serves the request.
 	requestId := r.Context().Value(RequestContextKey).(RequestContext).RequestId
-	helper.Logger.Printf(5, "STARTING %s %s%s RequestID:%s", r.Method, r.Host, r.URL, requestId)
+	helper.Logger.Printf(5, "[ %s ] STARTING %s %s%s RequestID:%s", requestId, r.Method, r.Host, r.URL, requestId)
 	l.handler.ServeHTTP(w, r)
-	helper.Logger.Printf(5, "COMPLETED %s %s%s RequestID:%s", r.Method, r.Host, r.URL, requestId)
+	helper.Logger.Printf(5, "[ %s ] COMPLETED %s %s%s RequestID:%s", requestId, r.Method, r.Host, r.URL, requestId)
 }
 
 func SetLogHandler(h http.Handler, _ *meta.Meta) http.Handler {

--- a/api/object-interface.go
+++ b/api/object-interface.go
@@ -29,70 +29,70 @@ import (
 // ObjectLayer implements primitives for object API layer.
 type ObjectLayer interface {
 	// Bucket operations.
-	MakeBucket(bucket string, acl datatype.Acl, credential common.Credential, ctx context.Context) error
-	SetBucketLc(bucket string, config datatype.Lc,
-		credential common.Credential, ctx context.Context) error
-	GetBucketLc(bucket string, credential common.Credential, ctx context.Context) (datatype.Lc, error)
-	DelBucketLc(bucket string, credential common.Credential, ctx context.Context) error
-	SetBucketAcl(bucket string, policy datatype.AccessControlPolicy, acl datatype.Acl,
-		credential common.Credential, ctx context.Context) error
-	GetBucketAcl(bucket string, credential common.Credential, ctx context.Context) (datatype.AccessControlPolicyResponse, error)
-	SetBucketCors(bucket string, cors datatype.Cors, credential common.Credential, ctx context.Context) error
-	SetBucketVersioning(bucket string, versioning datatype.Versioning, credential common.Credential, ctx context.Context) error
-	DeleteBucketCors(bucket string, credential common.Credential, ctx context.Context) error
-	GetBucketVersioning(bucket string, credential common.Credential, ctx context.Context) (datatype.Versioning, error)
-	GetBucketCors(bucket string, credential common.Credential, ctx context.Context) (datatype.Cors, error)
-	GetBucket(bucketName string, ctx context.Context) (bucket *meta.Bucket, err error) // For INTERNAL USE ONLY
-	GetBucketInfo(bucket string, credential common.Credential, ctx context.Context) (bucketInfo *meta.Bucket, err error)
-	ListBuckets(credential common.Credential, ctx context.Context) (buckets []meta.Bucket, err error)
-	DeleteBucket(bucket string, credential common.Credential, ctx context.Context) error
-	ListObjects(credential common.Credential, bucket string,
-		request datatype.ListObjectsRequest, ctx context.Context) (result meta.ListObjectsInfo, err error)
-	ListVersionedObjects(credential common.Credential, bucket string,
-		request datatype.ListObjectsRequest, ctx context.Context) (result meta.VersionedListObjectsInfo, err error)
+	MakeBucket(ctx context.Context, bucket string, acl datatype.Acl, credential common.Credential) error
+	SetBucketLc(ctx context.Context, bucket string, config datatype.Lc,
+		credential common.Credential) error
+	GetBucketLc(ctx context.Context, bucket string, credential common.Credential) (datatype.Lc, error)
+	DelBucketLc(ctx context.Context, bucket string, credential common.Credential) error
+	SetBucketAcl(ctx context.Context, bucket string, policy datatype.AccessControlPolicy, acl datatype.Acl,
+		credential common.Credential) error
+	GetBucketAcl(ctx context.Context, bucket string, credential common.Credential) (datatype.AccessControlPolicyResponse, error)
+	SetBucketCors(ctx context.Context, bucket string, cors datatype.Cors, credential common.Credential) error
+	SetBucketVersioning(ctx context.Context, bucket string, versioning datatype.Versioning, credential common.Credential) error
+	DeleteBucketCors(ctx context.Context, bucket string, credential common.Credential) error
+	GetBucketVersioning(ctx context.Context, bucket string, credential common.Credential) (datatype.Versioning, error)
+	GetBucketCors(ctx context.Context, bucket string, credential common.Credential) (datatype.Cors, error)
+	GetBucket(ctx context.Context, bucketName string) (bucket *meta.Bucket, err error) // For INTERNAL USE ONLY
+	GetBucketInfo(ctx context.Context, bucket string, credential common.Credential) (bucketInfo *meta.Bucket, err error)
+	ListBuckets(ctx context.Context, credential common.Credential) (buckets []meta.Bucket, err error)
+	DeleteBucket(ctx context.Context, bucket string, credential common.Credential) error
+	ListObjects(ctx context.Context, credential common.Credential, bucket string,
+		request datatype.ListObjectsRequest) (result meta.ListObjectsInfo, err error)
+	ListVersionedObjects(ctx context.Context, credential common.Credential, bucket string,
+		request datatype.ListObjectsRequest) (result meta.VersionedListObjectsInfo, err error)
 
-	SetBucketPolicy(credential common.Credential, bucket string, policy policy.Policy, ctx context.Context) error
+	SetBucketPolicy(ctx context.Context, credential common.Credential, bucket string, policy policy.Policy) error
 	// Policy operations
-	GetBucketPolicy(credential common.Credential, bucket string, ctx context.Context) (policy.Policy, error)
-	DeleteBucketPolicy(credential common.Credential, bucket string, ctx context.Context) error
+	GetBucketPolicy(ctx context.Context, credential common.Credential, bucket string) (policy.Policy, error)
+	DeleteBucketPolicy(ctx context.Context, credential common.Credential, bucket string) error
 
 	// Object operations.
-	GetObject(object *meta.Object, startOffset int64, length int64, writer io.Writer,
-		sse datatype.SseRequest, ctx context.Context) (err error)
-	GetObjectInfo(bucket, object, version string, credential common.Credential, ctx context.Context) (objInfo *meta.Object,
+	GetObject(ctx context.Context, object *meta.Object, startOffset int64, length int64, writer io.Writer,
+		sse datatype.SseRequest) (err error)
+	GetObjectInfo(ctx context.Context, bucket, object, version string, credential common.Credential) (objInfo *meta.Object,
 		err error)
-	PutObject(bucket, object string, credential common.Credential, size int64, data io.Reader,
+	PutObject(ctx context.Context, bucket, object string, credential common.Credential, size int64, data io.Reader,
 		metadata map[string]string, acl datatype.Acl,
-		sse datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (result datatype.PutObjectResult, err error)
-	AppendObject(bucket, object string, credential common.Credential, offset uint64, size int64, data io.Reader,
+		sse datatype.SseRequest, storageClass meta.StorageClass) (result datatype.PutObjectResult, err error)
+	AppendObject(ctx context.Context, bucket, object string, credential common.Credential, offset uint64, size int64, data io.Reader,
 		metadata map[string]string, acl datatype.Acl,
-		sse datatype.SseRequest, storageClass meta.StorageClass, objInfo *meta.Object, ctx context.Context) (result datatype.AppendObjectResult, err error)
+		sse datatype.SseRequest, storageClass meta.StorageClass, objInfo *meta.Object) (result datatype.AppendObjectResult, err error)
 
-	CopyObject(targetObject *meta.Object, source io.Reader, credential common.Credential,
-		sse datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult, err error)
-	UpdateObjectAttrs(targetObject *meta.Object, credential common.Credential, ctx context.Context) (result datatype.PutObjectResult, err error)
-	SetObjectAcl(bucket string, object string, version string, policy datatype.AccessControlPolicy,
-		acl datatype.Acl, credential common.Credential, ctx context.Context) error
-	GetObjectAcl(bucket string, object string, version string, credential common.Credential, ctx context.Context) (
+	CopyObject(ctx context.Context, targetObject *meta.Object, source io.Reader, credential common.Credential,
+		sse datatype.SseRequest) (result datatype.PutObjectResult, err error)
+	UpdateObjectAttrs(ctx context.Context, targetObject *meta.Object, credential common.Credential) (result datatype.PutObjectResult, err error)
+	SetObjectAcl(ctx context.Context, bucket string, object string, version string, policy datatype.AccessControlPolicy,
+		acl datatype.Acl, credential common.Credential) error
+	GetObjectAcl(ctx context.Context, bucket string, object string, version string, credential common.Credential) (
 		policy datatype.AccessControlPolicyResponse, err error)
-	DeleteObject(bucket, object, version string, credential common.Credential, ctx context.Context) (datatype.DeleteObjectResult,
+	DeleteObject(ctx context.Context, bucket, object, version string, credential common.Credential) (datatype.DeleteObjectResult,
 		error)
 
 	// Multipart operations.
-	ListMultipartUploads(credential common.Credential, bucket string,
-		request datatype.ListUploadsRequest, ctx context.Context) (result datatype.ListMultipartUploadsResponse, err error)
-	NewMultipartUpload(credential common.Credential, bucket, object string,
+	ListMultipartUploads(ctx context.Context, credential common.Credential, bucket string,
+		request datatype.ListUploadsRequest) (result datatype.ListMultipartUploadsResponse, err error)
+	NewMultipartUpload(ctx context.Context, credential common.Credential, bucket, object string,
 		metadata map[string]string, acl datatype.Acl,
-		sse datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (uploadID string, err error)
-	PutObjectPart(bucket, object string, credential common.Credential, uploadID string, partID int,
+		sse datatype.SseRequest, storageClass meta.StorageClass) (uploadID string, err error)
+	PutObjectPart(ctx context.Context, bucket, object string, credential common.Credential, uploadID string, partID int,
 		size int64, data io.Reader, md5Hex string,
-		sse datatype.SseRequest, ctx context.Context) (result datatype.PutObjectPartResult, err error)
-	CopyObjectPart(bucketName, objectName, uploadId string, partId int, size int64, data io.Reader,
-		credential common.Credential, sse datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult,
+		sse datatype.SseRequest) (result datatype.PutObjectPartResult, err error)
+	CopyObjectPart(ctx context.Context, bucketName, objectName, uploadId string, partId int, size int64, data io.Reader,
+		credential common.Credential, sse datatype.SseRequest) (result datatype.PutObjectResult,
 		err error)
-	ListObjectParts(credential common.Credential, bucket, object string,
-		request datatype.ListPartsRequest, ctx context.Context) (result datatype.ListPartsResponse, err error)
-	AbortMultipartUpload(credential common.Credential, bucket, object, uploadID string, ctx context.Context) error
-	CompleteMultipartUpload(credential common.Credential, bucket, object, uploadID string,
-		uploadedParts []meta.CompletePart, ctx context.Context) (result datatype.CompleteMultipartResult, err error)
+	ListObjectParts(ctx context.Context, credential common.Credential, bucket, object string,
+		request datatype.ListPartsRequest) (result datatype.ListPartsResponse, err error)
+	AbortMultipartUpload(ctx context.Context, credential common.Credential, bucket, object, uploadID string) error
+	CompleteMultipartUpload(ctx context.Context, credential common.Credential, bucket, object, uploadID string,
+		uploadedParts []meta.CompletePart) (result datatype.CompleteMultipartResult, err error)
 }

--- a/api/object-interface.go
+++ b/api/object-interface.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"context"
 	"io"
 
 	"github.com/journeymidnight/yig/api/datatype"
@@ -28,70 +29,70 @@ import (
 // ObjectLayer implements primitives for object API layer.
 type ObjectLayer interface {
 	// Bucket operations.
-	MakeBucket(bucket string, acl datatype.Acl, credential common.Credential) error
+	MakeBucket(bucket string, acl datatype.Acl, credential common.Credential, ctx context.Context) error
 	SetBucketLc(bucket string, config datatype.Lc,
-		credential common.Credential) error
-	GetBucketLc(bucket string, credential common.Credential) (datatype.Lc, error)
-	DelBucketLc(bucket string, credential common.Credential) error
+		credential common.Credential, ctx context.Context) error
+	GetBucketLc(bucket string, credential common.Credential, ctx context.Context) (datatype.Lc, error)
+	DelBucketLc(bucket string, credential common.Credential, ctx context.Context) error
 	SetBucketAcl(bucket string, policy datatype.AccessControlPolicy, acl datatype.Acl,
-		credential common.Credential) error
-	GetBucketAcl(bucket string, credential common.Credential) (datatype.AccessControlPolicyResponse, error)
-	SetBucketCors(bucket string, cors datatype.Cors, credential common.Credential) error
-	SetBucketVersioning(bucket string, versioning datatype.Versioning, credential common.Credential) error
-	DeleteBucketCors(bucket string, credential common.Credential) error
-	GetBucketVersioning(bucket string, credential common.Credential) (datatype.Versioning, error)
-	GetBucketCors(bucket string, credential common.Credential) (datatype.Cors, error)
-	GetBucket(bucketName string) (bucket *meta.Bucket, err error) // For INTERNAL USE ONLY
-	GetBucketInfo(bucket string, credential common.Credential) (bucketInfo *meta.Bucket, err error)
-	ListBuckets(credential common.Credential) (buckets []meta.Bucket, err error)
-	DeleteBucket(bucket string, credential common.Credential) error
+		credential common.Credential, ctx context.Context) error
+	GetBucketAcl(bucket string, credential common.Credential, ctx context.Context) (datatype.AccessControlPolicyResponse, error)
+	SetBucketCors(bucket string, cors datatype.Cors, credential common.Credential, ctx context.Context) error
+	SetBucketVersioning(bucket string, versioning datatype.Versioning, credential common.Credential, ctx context.Context) error
+	DeleteBucketCors(bucket string, credential common.Credential, ctx context.Context) error
+	GetBucketVersioning(bucket string, credential common.Credential, ctx context.Context) (datatype.Versioning, error)
+	GetBucketCors(bucket string, credential common.Credential, ctx context.Context) (datatype.Cors, error)
+	GetBucket(bucketName string, ctx context.Context) (bucket *meta.Bucket, err error) // For INTERNAL USE ONLY
+	GetBucketInfo(bucket string, credential common.Credential, ctx context.Context) (bucketInfo *meta.Bucket, err error)
+	ListBuckets(credential common.Credential, ctx context.Context) (buckets []meta.Bucket, err error)
+	DeleteBucket(bucket string, credential common.Credential, ctx context.Context) error
 	ListObjects(credential common.Credential, bucket string,
-		request datatype.ListObjectsRequest) (result meta.ListObjectsInfo, err error)
+		request datatype.ListObjectsRequest, ctx context.Context) (result meta.ListObjectsInfo, err error)
 	ListVersionedObjects(credential common.Credential, bucket string,
-		request datatype.ListObjectsRequest) (result meta.VersionedListObjectsInfo, err error)
+		request datatype.ListObjectsRequest, ctx context.Context) (result meta.VersionedListObjectsInfo, err error)
 
-	SetBucketPolicy(credential common.Credential, bucket string, policy policy.Policy) error
+	SetBucketPolicy(credential common.Credential, bucket string, policy policy.Policy, ctx context.Context) error
 	// Policy operations
-	GetBucketPolicy(credential common.Credential, bucket string) (policy.Policy, error)
-	DeleteBucketPolicy(credential common.Credential, bucket string) error
+	GetBucketPolicy(credential common.Credential, bucket string, ctx context.Context) (policy.Policy, error)
+	DeleteBucketPolicy(credential common.Credential, bucket string, ctx context.Context) error
 
 	// Object operations.
 	GetObject(object *meta.Object, startOffset int64, length int64, writer io.Writer,
-		sse datatype.SseRequest) (err error)
-	GetObjectInfo(bucket, object, version string, credential common.Credential) (objInfo *meta.Object,
+		sse datatype.SseRequest, ctx context.Context) (err error)
+	GetObjectInfo(bucket, object, version string, credential common.Credential, ctx context.Context) (objInfo *meta.Object,
 		err error)
 	PutObject(bucket, object string, credential common.Credential, size int64, data io.Reader,
 		metadata map[string]string, acl datatype.Acl,
-		sse datatype.SseRequest, storageClass meta.StorageClass) (result datatype.PutObjectResult, err error)
+		sse datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (result datatype.PutObjectResult, err error)
 	AppendObject(bucket, object string, credential common.Credential, offset uint64, size int64, data io.Reader,
 		metadata map[string]string, acl datatype.Acl,
-		sse datatype.SseRequest, storageClass meta.StorageClass, objInfo *meta.Object) (result datatype.AppendObjectResult, err error)
+		sse datatype.SseRequest, storageClass meta.StorageClass, objInfo *meta.Object, ctx context.Context) (result datatype.AppendObjectResult, err error)
 
 	CopyObject(targetObject *meta.Object, source io.Reader, credential common.Credential,
-		sse datatype.SseRequest) (result datatype.PutObjectResult, err error)
-	UpdateObjectAttrs(targetObject *meta.Object, credential common.Credential) (result datatype.PutObjectResult, err error)
+		sse datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult, err error)
+	UpdateObjectAttrs(targetObject *meta.Object, credential common.Credential, ctx context.Context) (result datatype.PutObjectResult, err error)
 	SetObjectAcl(bucket string, object string, version string, policy datatype.AccessControlPolicy,
-		acl datatype.Acl, credential common.Credential) error
-	GetObjectAcl(bucket string, object string, version string, credential common.Credential) (
+		acl datatype.Acl, credential common.Credential, ctx context.Context) error
+	GetObjectAcl(bucket string, object string, version string, credential common.Credential, ctx context.Context) (
 		policy datatype.AccessControlPolicyResponse, err error)
-	DeleteObject(bucket, object, version string, credential common.Credential) (datatype.DeleteObjectResult,
+	DeleteObject(bucket, object, version string, credential common.Credential, ctx context.Context) (datatype.DeleteObjectResult,
 		error)
 
 	// Multipart operations.
 	ListMultipartUploads(credential common.Credential, bucket string,
-		request datatype.ListUploadsRequest) (result datatype.ListMultipartUploadsResponse, err error)
+		request datatype.ListUploadsRequest, ctx context.Context) (result datatype.ListMultipartUploadsResponse, err error)
 	NewMultipartUpload(credential common.Credential, bucket, object string,
 		metadata map[string]string, acl datatype.Acl,
-		sse datatype.SseRequest, storageClass meta.StorageClass) (uploadID string, err error)
+		sse datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (uploadID string, err error)
 	PutObjectPart(bucket, object string, credential common.Credential, uploadID string, partID int,
 		size int64, data io.Reader, md5Hex string,
-		sse datatype.SseRequest) (result datatype.PutObjectPartResult, err error)
+		sse datatype.SseRequest, ctx context.Context) (result datatype.PutObjectPartResult, err error)
 	CopyObjectPart(bucketName, objectName, uploadId string, partId int, size int64, data io.Reader,
-		credential common.Credential, sse datatype.SseRequest) (result datatype.PutObjectResult,
+		credential common.Credential, sse datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult,
 		err error)
 	ListObjectParts(credential common.Credential, bucket, object string,
-		request datatype.ListPartsRequest) (result datatype.ListPartsResponse, err error)
-	AbortMultipartUpload(credential common.Credential, bucket, object, uploadID string) error
+		request datatype.ListPartsRequest, ctx context.Context) (result datatype.ListPartsResponse, err error)
+	AbortMultipartUpload(credential common.Credential, bucket, object, uploadID string, ctx context.Context) error
 	CompleteMultipartUpload(credential common.Credential, bucket, object, uploadID string,
-		uploadedParts []meta.CompletePart) (result datatype.CompleteMultipartResult, err error)
+		uploadedParts []meta.CompletePart, ctx context.Context) (result datatype.CompleteMultipartResult, err error)
 }

--- a/api/utils.go
+++ b/api/utils.go
@@ -74,7 +74,7 @@ func contains(stringList []string, element string) bool {
 	return false
 }
 
-func requestIdFromContext(ctx context.Context) string {
+func RequestIdFromContext(ctx context.Context) string {
 	if result, ok := ctx.Value(RequestContextKey).(RequestContext); ok {
 		return result.RequestId
 	}

--- a/api/utils.go
+++ b/api/utils.go
@@ -75,6 +75,10 @@ func contains(stringList []string, element string) bool {
 }
 
 func RequestIdFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	
 	if result, ok := ctx.Value(RequestContextKey).(RequestContext); ok {
 		return result.RequestId
 	}

--- a/conf/yig.toml
+++ b/conf/yig.toml
@@ -5,6 +5,8 @@ access_log_path = "/var/log/yig/access.log"
 access_log_format = "{combined}"
 panic_log_path = "/var/log/yig/panic.log"
 log_level = 20
+#"Panic":0, "Fatal":2, "Error":5, "Warn":10, "Info":12, "Debug":15, "Trace":20
+log_level_string = "Trace"
 pid_file = "/var/run/yig/yig.pid"
 api_listener = "0.0.0.0:8080"
 admin_listener = "0.0.0.0:9000"

--- a/helper/config.go
+++ b/helper/config.go
@@ -5,19 +5,19 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	. "github.com/journeymidnight/yig/log"
+	"github.com/journeymidnight/yig/log"
 )
 
 const (
-	YIG_CONF_PATH = "/etc/yig/yig.toml"
-	MIN_DOWNLOAD_BUFPOOL_SIZE = 512 << 10  // 512k
-	MAX_DOWNLOAD_BUFPOOL_SIZE = 8 << 20    // 8M
+	YIG_CONF_PATH             = "/etc/yig/yig.toml"
+	MIN_DOWNLOAD_BUFPOOL_SIZE = 512 << 10 // 512k
+	MAX_DOWNLOAD_BUFPOOL_SIZE = 8 << 20   // 8M
 )
 
 type Config struct {
 	S3Domain         []string                `toml:"s3domain"` // Domain name of YIG
 	Region           string                  `toml:"region"`   // Region name this instance belongs to, e.g cn-bj-1
-	Plugins          map[string]PluginConfig          `toml:"plugins"`
+	Plugins          map[string]PluginConfig `toml:"plugins"`
 	LogPath          string                  `toml:"log_path"`
 	AccessLogPath    string                  `toml:"access_log_path"`
 	AccessLogFormat  string                  `toml:"access_log_format"`
@@ -78,9 +78,9 @@ type Config struct {
 }
 
 type PluginConfig struct {
-        Path string  `toml:"path"`
-        Enable bool  `toml:"enable"`
-        Args  map[string]interface{} `toml:"args"`
+	Path   string                 `toml:"path"`
+	Enable bool                   `toml:"enable"`
+	Args   map[string]interface{} `toml:"args"`
 }
 
 type KMSConfig struct {
@@ -113,14 +113,14 @@ type MsgBusConfig struct {
 
 var CONFIG Config
 
-var LOG_LEVEL_MAP = map[string]int {
-	"Panic":        LOG_PANIC,
-	"Fatal":        LOG_FATAL,
-	"Error":        LOG_ERROR,
-	"Warn":         LOG_WARN,
-	"Info":         LOG_INFO,
-	"Debug":        LOG_DEBUG,
-	"Trace":        LOG_TRACE,
+var LOG_LEVEL_MAP = map[string]int{
+	"Panic": log.LOG_PANIC,
+	"Fatal": log.LOG_FATAL,
+	"Error": log.LOG_ERROR,
+	"Warn":  log.LOG_WARN,
+	"Info":  log.LOG_INFO,
+	"Debug": log.LOG_DEBUG,
+	"Trace": log.LOG_TRACE,
 }
 
 func SetupConfig() {

--- a/helper/config.go
+++ b/helper/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	. "github.com/journeymidnight/yig/log"
 )
 
 const (
@@ -38,6 +39,7 @@ type Config struct {
 	LcThread               int           //used for tools/lc only, set worker numbers to do lc
 	LcDebug                bool          //used for tools/lc only, if this was set true, will treat days as seconds
 	LogLevel               int           `toml:"log_level"` //1-20
+	LogLevelString         string        `toml:"log_level_string"`
 	CephConfigPattern      string        `toml:"ceph_config_pattern"`
 	ReservedOrigins        string        `toml:"reserved_origins"` // www.ccc.com,www.bbb.com,127.0.0.1
 	MetaStore              string        `toml:"meta_store"`
@@ -111,6 +113,16 @@ type MsgBusConfig struct {
 
 var CONFIG Config
 
+var LOG_LEVEL_MAP = map[string]int {
+	"Panic":        LOG_PANIC,
+	"Fatal":        LOG_FATAL,
+	"Error":        LOG_ERROR,
+	"Warn":         LOG_WARN,
+	"Info":         LOG_INFO,
+	"Debug":        LOG_DEBUG,
+	"Trace":        LOG_TRACE,
+}
+
 func SetupConfig() {
 	MarshalTOMLConfig()
 }
@@ -161,6 +173,8 @@ func MarshalTOMLConfig() error {
 	CONFIG.LcThread = Ternary(c.LcThread == 0,
 		1, c.LcThread).(int)
 	CONFIG.LogLevel = Ternary(c.LogLevel == 0, 5, c.LogLevel).(int)
+	logLevel, ok := LOG_LEVEL_MAP[CONFIG.LogLevelString]
+	CONFIG.LogLevel = Ternary(ok, logLevel, CONFIG.LogLevel).(int)
 	CONFIG.MetaStore = Ternary(c.MetaStore == "", "tidb", c.MetaStore).(string)
 
 	CONFIG.RedisAddress = c.RedisAddress

--- a/helper/logger.go
+++ b/helper/logger.go
@@ -97,8 +97,12 @@ func FatalIf(err error, msg string, data ...interface{}) {
 
 // To avoid looped dependency.
 // api.RequestIdFromContext() requires RequestContext, while RequestContext depends on meta package.
-func RequestIdFromContext(context context.Context) string {
-	if result, ok := context.Value(RequestIdKeyString).(string); ok {
+func RequestIdFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	if result, ok := ctx.Value(RequestIdKeyString).(string); ok {
 		return result
 	}
 

--- a/helper/logger.go
+++ b/helper/logger.go
@@ -19,17 +19,21 @@ package helper
 import (
 	"bufio"
 	"bytes"
-	"github.com/dustin/go-humanize"
-	"github.com/journeymidnight/yig/log"
+	"context"
 	"os"
 	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/journeymidnight/yig/log"
 )
 
 var Logger *log.Logger
 var AccessLogger *log.Logger
+
+const RequestIdKeyString = "RequestId"
 
 // sysInfo returns useful system statistics.
 func sysInfo() map[string]string {
@@ -89,4 +93,14 @@ func FatalIf(err error, msg string, data ...interface{}) {
 	Logger.Println(5, "System Info: ", sysInfo())
 	Logger.Println(5, "Stack trace: ", stackInfo())
 	os.Exit(1)
+}
+
+// To avoid looped dependency.
+// api.RequestIdFromContext() requires RequestContext, while RequestContext depends on meta package.
+func RequestIdFromContext(context context.Context) string {
+	if result, ok := context.Value(RequestIdKeyString).(string); ok {
+		return result
+	}
+
+	return ""
 }

--- a/log/log.go
+++ b/log/log.go
@@ -28,6 +28,16 @@ const (
 	LstdFlags     = Ldate | Ltime // initial values for the standard logger
 )
 
+const (
+	LOG_PANIC	= 1
+	LOG_FATAL	= 2
+	LOG_ERROR	= 5
+	LOG_WARN	= 10
+	LOG_INFO	= 12
+	LOG_DEBUG	= 15
+	LOG_TRACE	= 20
+)
+
 type Logger struct {
 	Logger   *log.Logger
 	LogLevel int

--- a/meta/bucket.go
+++ b/meta/bucket.go
@@ -11,7 +11,7 @@ import (
 
 // Note the usage info got from this method is possibly not accurate because we don't
 // invalid cache when updating usage. For accurate usage info, use `GetUsage()`
-func (m *Meta) GetBucket(bucketName string, willNeed bool, ctx context.Context) (bucket *Bucket, err error) {
+func (m *Meta) GetBucket(ctx context.Context, bucketName string, willNeed bool) (bucket *Bucket, err error) {
 	getBucket := func() (b interface{}, err error) {
 		b, err = m.Client.GetBucket(bucketName)
 		helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]",
@@ -23,7 +23,7 @@ func (m *Meta) GetBucket(bucketName string, willNeed bool, ctx context.Context) 
 		err := helper.MsgPackUnMarshal(in, &bucket)
 		return &bucket, err
 	}
-	b, err := m.Cache.Get(redis.BucketTable, bucketName, getBucket, unmarshaller, willNeed, ctx)
+	b, err := m.Cache.Get(ctx, redis.BucketTable, bucketName, getBucket, unmarshaller, willNeed)
 	if err != nil {
 		return
 	}
@@ -45,27 +45,27 @@ func (m *Meta) UpdateUsage(bucketName string, size int64) {
 	m.Client.UpdateUsage(bucketName, size, nil)
 }
 
-func (m *Meta) GetUsage(bucketName string, ctx context.Context) (int64, error) {
+func (m *Meta) GetUsage(ctx context.Context, bucketName string) (int64, error) {
 	m.Cache.Remove(redis.BucketTable, bucketName)
-	bucket, err := m.GetBucket(bucketName, true, ctx)
+	bucket, err := m.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		return 0, err
 	}
 	return bucket.Usage, nil
 }
 
-func (m *Meta) GetBucketInfo(bucketName string, ctx context.Context) (*Bucket, error) {
+func (m *Meta) GetBucketInfo(ctx context.Context, bucketName string) (*Bucket, error) {
 	m.Cache.Remove(redis.BucketTable, bucketName)
-	bucket, err := m.GetBucket(bucketName, true, ctx)
+	bucket, err := m.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		return bucket, err
 	}
 	return bucket, nil
 }
 
-func (m *Meta) GetUserInfo(uid string, ctx context.Context) ([]string, error) {
+func (m *Meta) GetUserInfo(ctx context.Context, uid string) ([]string, error) {
 	m.Cache.Remove(redis.UserTable, uid)
-	buckets, err := m.GetUserBuckets(uid, true, ctx)
+	buckets, err := m.GetUserBuckets(ctx, uid, true)
 	if err != nil {
 		return nil, err
 	}

--- a/meta/bucket.go
+++ b/meta/bucket.go
@@ -1,6 +1,8 @@
 package meta
 
 import (
+	"context"
+
 	. "github.com/journeymidnight/yig/error"
 	"github.com/journeymidnight/yig/helper"
 	. "github.com/journeymidnight/yig/meta/types"
@@ -9,10 +11,11 @@ import (
 
 // Note the usage info got from this method is possibly not accurate because we don't
 // invalid cache when updating usage. For accurate usage info, use `GetUsage()`
-func (m *Meta) GetBucket(bucketName string, willNeed bool) (bucket *Bucket, err error) {
+func (m *Meta) GetBucket(bucketName string, willNeed bool, ctx context.Context) (bucket *Bucket, err error) {
 	getBucket := func() (b interface{}, err error) {
 		b, err = m.Client.GetBucket(bucketName)
-		helper.Logger.Println(10, "GetBucket CacheMiss. bucket:", bucketName)
+		helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]",
+			"GetBucket CacheMiss. bucket:", bucketName)
 		return b, err
 	}
 	unmarshaller := func(in []byte) (interface{}, error) {
@@ -20,13 +23,13 @@ func (m *Meta) GetBucket(bucketName string, willNeed bool) (bucket *Bucket, err 
 		err := helper.MsgPackUnMarshal(in, &bucket)
 		return &bucket, err
 	}
-	b, err := m.Cache.Get(redis.BucketTable, bucketName, getBucket, unmarshaller, willNeed)
+	b, err := m.Cache.Get(redis.BucketTable, bucketName, getBucket, unmarshaller, willNeed, ctx)
 	if err != nil {
 		return
 	}
 	bucket, ok := b.(*Bucket)
 	if !ok {
-		helper.Debugln("Cast b failed:", b)
+		helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "Cast b failed:", b)
 		err = ErrInternalError
 		return
 	}
@@ -42,27 +45,27 @@ func (m *Meta) UpdateUsage(bucketName string, size int64) {
 	m.Client.UpdateUsage(bucketName, size, nil)
 }
 
-func (m *Meta) GetUsage(bucketName string) (int64, error) {
+func (m *Meta) GetUsage(bucketName string, ctx context.Context) (int64, error) {
 	m.Cache.Remove(redis.BucketTable, bucketName)
-	bucket, err := m.GetBucket(bucketName, true)
+	bucket, err := m.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return 0, err
 	}
 	return bucket.Usage, nil
 }
 
-func (m *Meta) GetBucketInfo(bucketName string) (*Bucket, error) {
+func (m *Meta) GetBucketInfo(bucketName string, ctx context.Context) (*Bucket, error) {
 	m.Cache.Remove(redis.BucketTable, bucketName)
-	bucket, err := m.GetBucket(bucketName, true)
+	bucket, err := m.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return bucket, err
 	}
 	return bucket, nil
 }
 
-func (m *Meta) GetUserInfo(uid string) ([]string, error) {
+func (m *Meta) GetUserInfo(uid string, ctx context.Context) ([]string, error) {
 	m.Cache.Remove(redis.UserTable, uid)
-	buckets, err := m.GetUserBuckets(uid, true)
+	buckets, err := m.GetUserBuckets(uid, true, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/meta/client/client.go
+++ b/meta/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+
 	"github.com/journeymidnight/yig/api/datatype"
 	. "github.com/journeymidnight/yig/meta/types"
 )
@@ -41,9 +43,9 @@ type Client interface {
 	//cluster
 	GetCluster(fsid, pool string) (cluster Cluster, err error)
 	//lc
-	PutBucketToLifeCycle(lifeCycle LifeCycle) error
-	RemoveBucketFromLifeCycle(bucket Bucket) error
-	ScanLifeCycle(limit int, marker string) (result ScanLifeCycleResult, err error)
+	PutBucketToLifeCycle(lifeCycle LifeCycle, ctx context.Context) error
+	RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Context) error
+	ScanLifeCycle(limit int, marker string, ctx context.Context) (result ScanLifeCycleResult, err error)
 	//user
 	GetUserBuckets(userId string) (buckets []string, err error)
 	AddBucketForUser(bucketName, userId string) (err error)

--- a/meta/client/client.go
+++ b/meta/client/client.go
@@ -43,9 +43,9 @@ type Client interface {
 	//cluster
 	GetCluster(fsid, pool string) (cluster Cluster, err error)
 	//lc
-	PutBucketToLifeCycle(lifeCycle LifeCycle, ctx context.Context) error
-	RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Context) error
-	ScanLifeCycle(limit int, marker string, ctx context.Context) (result ScanLifeCycleResult, err error)
+	PutBucketToLifeCycle(ctx context.Context, lifeCycle LifeCycle) error
+	RemoveBucketFromLifeCycle(ctx context.Context, bucket Bucket) error
+	ScanLifeCycle(ctx context.Context, limit int, marker string) (result ScanLifeCycleResult, err error)
 	//user
 	GetUserBuckets(userId string) (buckets []string, err error)
 	AddBucketForUser(bucketName, userId string) (err error)

--- a/meta/client/tidbclient/lc.go
+++ b/meta/client/tidbclient/lc.go
@@ -1,33 +1,34 @@
 package tidbclient
 
 import (
+	"context"
 	"database/sql"
+
 	"github.com/journeymidnight/yig/helper"
 	. "github.com/journeymidnight/yig/meta/types"
 )
 
-func (t *TidbClient) PutBucketToLifeCycle(lifeCycle LifeCycle) error {
+func (t *TidbClient) PutBucketToLifeCycle(lifeCycle LifeCycle, ctx context.Context) error {
 	sqltext := "insert into lifecycle(bucketname,status) values (?,?);"
 	_, err := t.Client.Exec(sqltext, lifeCycle.BucketName, lifeCycle.Status)
 	if err != nil {
-		helper.Logger.Printf(0, "Failed in PutBucketToLifeCycle: %s\n", sqltext)
+		helper.Logger.Printf(0, "[", helper.RequestIdFromContext(ctx), "]", "Failed in PutBucketToLifeCycle: %s\n", sqltext)
 		return nil
 	}
 	return nil
 }
 
-
-func (t *TidbClient) RemoveBucketFromLifeCycle(bucket Bucket) error {
+func (t *TidbClient) RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Context) error {
 	sqltext := "delete from lifecycle where bucketname=?;"
 	_, err := t.Client.Exec(sqltext, bucket.Name)
 	if err != nil {
-		helper.Logger.Printf(0, "Failed in RemoveBucketFromLifeCycle: %s\n", sqltext)
+		helper.Logger.Printf(0, "[", helper.RequestIdFromContext(ctx), "]", "Failed in RemoveBucketFromLifeCycle: %s\n", sqltext)
 		return nil
 	}
 	return nil
 }
 
-func (t *TidbClient) ScanLifeCycle(limit int, marker string) (result ScanLifeCycleResult, err error) {
+func (t *TidbClient) ScanLifeCycle(limit int, marker string, ctx context.Context) (result ScanLifeCycleResult, err error) {
 	result.Truncated = false
 	sqltext := "select * from lifecycle where bucketname > ? limit ?;"
 	rows, err := t.Client.Query(sqltext, marker, limit)
@@ -46,14 +47,14 @@ func (t *TidbClient) ScanLifeCycle(limit int, marker string) (result ScanLifeCyc
 			&lc.BucketName,
 			&lc.Status)
 		if err != nil {
-			helper.Logger.Printf(0, "Failed in ScanLifeCycle: %s ... %s\n", result.Lcs,result.NextMarker)
+			helper.Logger.Printf(0, "[", helper.RequestIdFromContext(ctx), "]", "Failed in ScanLifeCycle: %s ... %s\n", result.Lcs, result.NextMarker)
 			return
 		}
 		result.Lcs = append(result.Lcs, lc)
 	}
 	result.NextMarker = lc.BucketName
-	if len(result.Lcs) == limit{
+	if len(result.Lcs) == limit {
 		result.Truncated = true
 	}
-	return result,nil
+	return result, nil
 }

--- a/meta/client/tidbclient/lc.go
+++ b/meta/client/tidbclient/lc.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/journeymidnight/yig/meta/types"
 )
 
-func (t *TidbClient) PutBucketToLifeCycle(lifeCycle LifeCycle, ctx context.Context) error {
+func (t *TidbClient) PutBucketToLifeCycle(ctx context.Context, lifeCycle LifeCycle) error {
 	sqltext := "insert into lifecycle(bucketname,status) values (?,?);"
 	_, err := t.Client.Exec(sqltext, lifeCycle.BucketName, lifeCycle.Status)
 	if err != nil {
@@ -18,7 +18,7 @@ func (t *TidbClient) PutBucketToLifeCycle(lifeCycle LifeCycle, ctx context.Conte
 	return nil
 }
 
-func (t *TidbClient) RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Context) error {
+func (t *TidbClient) RemoveBucketFromLifeCycle(ctx context.Context, bucket Bucket) error {
 	sqltext := "delete from lifecycle where bucketname=?;"
 	_, err := t.Client.Exec(sqltext, bucket.Name)
 	if err != nil {
@@ -28,7 +28,7 @@ func (t *TidbClient) RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Contex
 	return nil
 }
 
-func (t *TidbClient) ScanLifeCycle(limit int, marker string, ctx context.Context) (result ScanLifeCycleResult, err error) {
+func (t *TidbClient) ScanLifeCycle(ctx context.Context, limit int, marker string) (result ScanLifeCycleResult, err error) {
 	result.Truncated = false
 	sqltext := "select * from lifecycle where bucketname > ? limit ?;"
 	rows, err := t.Client.Query(sqltext, marker, limit)

--- a/meta/cluster.go
+++ b/meta/cluster.go
@@ -9,7 +9,7 @@ import (
 	"github.com/journeymidnight/yig/redis"
 )
 
-func (m *Meta) GetCluster(fsid string, pool string, ctx context.Context) (cluster Cluster, err error) {
+func (m *Meta) GetCluster(ctx context.Context, fsid string, pool string) (cluster Cluster, err error) {
 	rowKey := fsid + ObjectNameSeparator + pool
 	getCluster := func() (c interface{}, err error) {
 		helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]", "GetCluster CacheMiss. fsid:", fsid)
@@ -20,7 +20,7 @@ func (m *Meta) GetCluster(fsid string, pool string, ctx context.Context) (cluste
 		err := helper.MsgPackUnMarshal(in, &cluster)
 		return cluster, err
 	}
-	c, err := m.Cache.Get(redis.ClusterTable, rowKey, getCluster, unmarshaller, true, ctx)
+	c, err := m.Cache.Get(ctx, redis.ClusterTable, rowKey, getCluster, unmarshaller, true)
 	if err != nil {
 		return
 	}

--- a/meta/cluster.go
+++ b/meta/cluster.go
@@ -1,16 +1,18 @@
 package meta
 
 import (
+	"context"
+
 	. "github.com/journeymidnight/yig/error"
 	"github.com/journeymidnight/yig/helper"
 	. "github.com/journeymidnight/yig/meta/types"
 	"github.com/journeymidnight/yig/redis"
 )
 
-func (m *Meta) GetCluster(fsid string, pool string) (cluster Cluster, err error) {
+func (m *Meta) GetCluster(fsid string, pool string, ctx context.Context) (cluster Cluster, err error) {
 	rowKey := fsid + ObjectNameSeparator + pool
 	getCluster := func() (c interface{}, err error) {
-		helper.Logger.Println(10, "GetCluster CacheMiss. fsid:", fsid)
+		helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]", "GetCluster CacheMiss. fsid:", fsid)
 		return m.Client.GetCluster(fsid, pool)
 	}
 	unmarshaller := func(in []byte) (interface{}, error) {
@@ -18,7 +20,7 @@ func (m *Meta) GetCluster(fsid string, pool string) (cluster Cluster, err error)
 		err := helper.MsgPackUnMarshal(in, &cluster)
 		return cluster, err
 	}
-	c, err := m.Cache.Get(redis.ClusterTable, rowKey, getCluster, unmarshaller, true)
+	c, err := m.Cache.Get(redis.ClusterTable, rowKey, getCluster, unmarshaller, true, ctx)
 	if err != nil {
 		return
 	}

--- a/meta/lifecycle.go
+++ b/meta/lifecycle.go
@@ -1,6 +1,10 @@
 package meta
 
-import . "github.com/journeymidnight/yig/meta/types"
+import (
+	"context"
+
+	. "github.com/journeymidnight/yig/meta/types"
+)
 
 func LifeCycleFromBucket(b Bucket) (lc LifeCycle) {
 	lc.BucketName = b.Name
@@ -8,15 +12,15 @@ func LifeCycleFromBucket(b Bucket) (lc LifeCycle) {
 	return
 }
 
-func (m *Meta) PutBucketToLifeCycle(bucket Bucket) error {
+func (m *Meta) PutBucketToLifeCycle(bucket Bucket, ctx context.Context) error {
 	lifeCycle := LifeCycleFromBucket(bucket)
-	return m.Client.PutBucketToLifeCycle(lifeCycle)
+	return m.Client.PutBucketToLifeCycle(lifeCycle, ctx)
 }
 
-func (m *Meta) RemoveBucketFromLifeCycle(bucket Bucket) error {
-	return m.Client.RemoveBucketFromLifeCycle(bucket)
+func (m *Meta) RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Context) error {
+	return m.Client.RemoveBucketFromLifeCycle(bucket, ctx)
 }
 
-func (m *Meta) ScanLifeCycle(limit int, marker string) (result ScanLifeCycleResult, err error) {
-	return m.Client.ScanLifeCycle(limit, marker)
+func (m *Meta) ScanLifeCycle(limit int, marker string, ctx context.Context) (result ScanLifeCycleResult, err error) {
+	return m.Client.ScanLifeCycle(limit, marker, ctx)
 }

--- a/meta/lifecycle.go
+++ b/meta/lifecycle.go
@@ -12,15 +12,15 @@ func LifeCycleFromBucket(b Bucket) (lc LifeCycle) {
 	return
 }
 
-func (m *Meta) PutBucketToLifeCycle(bucket Bucket, ctx context.Context) error {
+func (m *Meta) PutBucketToLifeCycle(ctx context.Context, bucket Bucket) error {
 	lifeCycle := LifeCycleFromBucket(bucket)
-	return m.Client.PutBucketToLifeCycle(lifeCycle, ctx)
+	return m.Client.PutBucketToLifeCycle(ctx, lifeCycle)
 }
 
-func (m *Meta) RemoveBucketFromLifeCycle(bucket Bucket, ctx context.Context) error {
-	return m.Client.RemoveBucketFromLifeCycle(bucket, ctx)
+func (m *Meta) RemoveBucketFromLifeCycle(ctx context.Context, bucket Bucket) error {
+	return m.Client.RemoveBucketFromLifeCycle(ctx, bucket)
 }
 
-func (m *Meta) ScanLifeCycle(limit int, marker string, ctx context.Context) (result ScanLifeCycleResult, err error) {
-	return m.Client.ScanLifeCycle(limit, marker, ctx)
+func (m *Meta) ScanLifeCycle(ctx context.Context, limit int, marker string) (result ScanLifeCycleResult, err error) {
+	return m.Client.ScanLifeCycle(ctx, limit, marker)
 }

--- a/meta/object.go
+++ b/meta/object.go
@@ -9,7 +9,7 @@ import (
 	"github.com/journeymidnight/yig/redis"
 )
 
-func (m *Meta) GetObject(bucketName string, objectName string, willNeed bool, ctx context.Context) (object *Object, err error) {
+func (m *Meta) GetObject(ctx context.Context, bucketName string, objectName string, willNeed bool) (object *Object, err error) {
 	getObject := func() (o interface{}, err error) {
 		helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]",
 			"GetObject CacheMiss. bucket:", bucketName, "object:", objectName)
@@ -30,8 +30,8 @@ func (m *Meta) GetObject(bucketName string, objectName string, willNeed bool, ct
 		return &object, err
 	}
 
-	o, err := m.Cache.Get(redis.ObjectTable, bucketName+":"+objectName+":",
-		getObject, unmarshaller, willNeed, ctx)
+	o, err := m.Cache.Get(ctx, redis.ObjectTable, bucketName+":"+objectName+":",
+		getObject, unmarshaller, willNeed)
 	if err != nil {
 		return
 	}
@@ -52,7 +52,7 @@ func (m *Meta) GetObjectMap(bucketName, objectName string) (objMap *ObjMap, err 
 	return
 }
 
-func (m *Meta) GetObjectVersion(bucketName, objectName, version string, willNeed bool, ctx context.Context) (object *Object, err error) {
+func (m *Meta) GetObjectVersion(ctx context.Context, bucketName, objectName, version string, willNeed bool) (object *Object, err error) {
 	getObjectVersion := func() (o interface{}, err error) {
 		object, err := m.Client.GetObject(bucketName, objectName, version)
 		if err != nil {
@@ -69,8 +69,8 @@ func (m *Meta) GetObjectVersion(bucketName, objectName, version string, willNeed
 		err := helper.MsgPackUnMarshal(in, &object)
 		return &object, err
 	}
-	o, err := m.Cache.Get(redis.ObjectTable, bucketName+":"+objectName+":"+version,
-		getObjectVersion, unmarshaller, willNeed, ctx)
+	o, err := m.Cache.Get(ctx, redis.ObjectTable, bucketName+":"+objectName+":"+version,
+		getObjectVersion, unmarshaller, willNeed)
 	if err != nil {
 		return
 	}

--- a/meta/user.go
+++ b/meta/user.go
@@ -12,7 +12,7 @@ const (
 	BUCKET_NUMBER_LIMIT = 100
 )
 
-func (m *Meta) GetUserBuckets(userId string, willNeed bool, ctx context.Context) (buckets []string, err error) {
+func (m *Meta) GetUserBuckets(ctx context.Context, userId string, willNeed bool) (buckets []string, err error) {
 	getUserBuckets := func() (bs interface{}, err error) {
 		return m.Client.GetUserBuckets(userId)
 	}
@@ -21,7 +21,7 @@ func (m *Meta) GetUserBuckets(userId string, willNeed bool, ctx context.Context)
 		err := helper.MsgPackUnMarshal(in, &buckets)
 		return buckets, err
 	}
-	bs, err := m.Cache.Get(redis.UserTable, userId, getUserBuckets, unmarshaller, willNeed, ctx)
+	bs, err := m.Cache.Get(ctx, redis.UserTable, userId, getUserBuckets, unmarshaller, willNeed)
 	if err != nil {
 		return
 	}
@@ -34,8 +34,8 @@ func (m *Meta) GetUserBuckets(userId string, willNeed bool, ctx context.Context)
 	return buckets, nil
 }
 
-func (m *Meta) AddBucketForUser(bucketName string, userId string, ctx context.Context) (err error) {
-	buckets, err := m.GetUserBuckets(userId, false, ctx)
+func (m *Meta) AddBucketForUser(ctx context.Context, bucketName string, userId string) (err error) {
+	buckets, err := m.GetUserBuckets(ctx, userId, false)
 	if err != nil {
 		return err
 	}

--- a/signature/postpolicyform.go
+++ b/signature/postpolicyform.go
@@ -196,8 +196,8 @@ func parsePostPolicyForm(policy string,
 }
 
 // checkPostPolicy - apply policy conditions and validate input values.
-func CheckPostPolicy(formValues map[string]string,
-	postPolicyVersion PostPolicyType, ctx context.Context) error {
+func CheckPostPolicy(ctx context.Context, formValues map[string]string,
+	postPolicyVersion PostPolicyType) error {
 
 	var eqPolicyRegExp, startswithPolicyRegExp, ignoredFormRegExp *regexp.Regexp
 	switch postPolicyVersion {

--- a/signature/postpolicyform.go
+++ b/signature/postpolicyform.go
@@ -17,6 +17,7 @@
 package signature
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -24,10 +25,11 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/journeymidnight/yig/error"
-	"github.com/journeymidnight/yig/helper"
 	"net/http"
 	"regexp"
+
+	. "github.com/journeymidnight/yig/error"
+	"github.com/journeymidnight/yig/helper"
 )
 
 var (
@@ -195,7 +197,7 @@ func parsePostPolicyForm(policy string,
 
 // checkPostPolicy - apply policy conditions and validate input values.
 func CheckPostPolicy(formValues map[string]string,
-	postPolicyVersion PostPolicyType) error {
+	postPolicyVersion PostPolicyType, ctx context.Context) error {
 
 	var eqPolicyRegExp, startswithPolicyRegExp, ignoredFormRegExp *regexp.Regexp
 	switch postPolicyVersion {
@@ -220,7 +222,7 @@ func CheckPostPolicy(formValues map[string]string,
 	postPolicyForm, err := parsePostPolicyForm(string(policyBytes),
 		eqPolicyRegExp, startswithPolicyRegExp)
 	if err != nil {
-		helper.Logger.Println(5, "Parse post-policy form error:", err)
+		helper.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Parse post-policy form error:", err)
 		return ErrMalformedPOSTRequest
 	}
 	if !postPolicyForm.Expiration.After(time.Now()) {

--- a/signature/v2.go
+++ b/signature/v2.go
@@ -57,7 +57,7 @@ func verifyNotExpires(dateString string) (bool, error) {
 	return true, nil
 }
 
-func buildCanonicalizedAmzHeaders(headers *http.Header, ctx context.Context) string {
+func buildCanonicalizedAmzHeaders(ctx context.Context, headers *http.Header) string {
 	var amzHeaders []string
 	for k, _ := range *headers {
 		if strings.HasPrefix(strings.ToLower(k), "x-amz-") {
@@ -187,7 +187,7 @@ func DoesSignatureMatchV2(r *http.Request) (credential common.Credential, err er
 		stringToSign += date + "\n"
 	}
 
-	stringToSign += buildCanonicalizedAmzHeaders(&r.Header, r.Context())
+	stringToSign += buildCanonicalizedAmzHeaders(r.Context(), &r.Header)
 	stringToSign += buildCanonicalizedResource(r)
 
 	helper.Debugln("[", requestId, "]", "stringtosign", stringToSign, credential.SecretAccessKey)
@@ -225,7 +225,7 @@ func DoesPresignedSignatureMatchV2(r *http.Request) (credential common.Credentia
 	stringToSign += r.Header.Get("Content-Md5") + "\n"
 	stringToSign += r.Header.Get("Content-Type") + "\n"
 	stringToSign += expires + "\n"
-	stringToSign += buildCanonicalizedAmzHeaders(&r.Header, r.Context())
+	stringToSign += buildCanonicalizedAmzHeaders(r.Context(), &r.Header)
 	stringToSign += buildCanonicalizedResource(r)
 
 	return credential, dictate(credential.SecretAccessKey, stringToSign, signature, helper.RequestIdFromContext((r.Context())))

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"time"
@@ -18,7 +19,7 @@ import (
 )
 
 func (yig *YigStorage) MakeBucket(bucketName string, acl datatype.Acl,
-	credential common.Credential) error {
+	credential common.Credential, ctx context.Context) error {
 	// Input validation.
 	if err := api.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -34,13 +35,13 @@ func (yig *YigStorage) MakeBucket(bucketName string, acl datatype.Acl,
 	}
 	processed, err := yig.MetaStorage.Client.CheckAndPutBucket(bucket)
 	if err != nil {
-		yig.Logger.Println(5, "Error making checkandput: ", err)
+		yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error making checkandput: ", err)
 		return err
 	}
 	if !processed { // bucket already exists, return accurate message
-		bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+		bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 		if err != nil {
-			yig.Logger.Println(5, "Error get bucket: ", bucketName, ", with error", err)
+			yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error get bucket: ", bucketName, ", with error", err)
 			return ErrBucketAlreadyExists
 		}
 		if bucket.OwnerId == credential.UserId {
@@ -49,13 +50,13 @@ func (yig *YigStorage) MakeBucket(bucketName string, acl datatype.Acl,
 			return ErrBucketAlreadyExists
 		}
 	}
-	err = yig.MetaStorage.AddBucketForUser(bucketName, credential.UserId)
+	err = yig.MetaStorage.AddBucketForUser(bucketName, credential.UserId, ctx)
 	if err != nil { // roll back bucket table, i.e. remove inserted bucket
-		yig.Logger.Println(5, "Error AddBucketForUser: ", err)
+		yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error AddBucketForUser: ", err)
 		err = yig.MetaStorage.Client.DeleteBucket(bucket)
 		if err != nil {
-			yig.Logger.Println(5, "Error deleting: ", err)
-			yig.Logger.Println(5, "Leaving junk bucket unremoved: ", bucketName)
+			yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error deleting: ", err)
+			yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Leaving junk bucket unremoved: ", bucketName)
 			return err
 		}
 	}
@@ -66,17 +67,17 @@ func (yig *YigStorage) MakeBucket(bucketName string, acl datatype.Acl,
 }
 
 func (yig *YigStorage) SetBucketAcl(bucketName string, policy datatype.AccessControlPolicy, acl datatype.Acl,
-	credential common.Credential) error {
+	credential common.Credential, ctx context.Context) error {
 
 	if acl.CannedAcl == "" {
-		newCannedAcl, err := datatype.GetCannedAclFromPolicy(policy)
+		newCannedAcl, err := datatype.GetCannedAclFromPolicy(policy, ctx)
 		if err != nil {
 			return err
 		}
 		acl = newCannedAcl
 	}
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -95,9 +96,9 @@ func (yig *YigStorage) SetBucketAcl(bucketName string, policy datatype.AccessCon
 }
 
 func (yig *YigStorage) SetBucketLc(bucketName string, lc datatype.Lc,
-	credential common.Credential) error {
-	helper.Logger.Println(10, "enter SetBucketLc")
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	credential common.Credential, ctx context.Context) error {
+	helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]", "enter SetBucketLc")
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return err
 	}
@@ -113,17 +114,17 @@ func (yig *YigStorage) SetBucketLc(bucketName string, lc datatype.Lc,
 		yig.MetaStorage.Cache.Remove(redis.BucketTable, bucketName)
 	}
 
-	err = yig.MetaStorage.PutBucketToLifeCycle(*bucket)
+	err = yig.MetaStorage.PutBucketToLifeCycle(*bucket, ctx)
 	if err != nil {
-		yig.Logger.Println(5, "Error Put bucket to LC table: ", err)
+		yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error Put bucket to LC table: ", err)
 		return err
 	}
 	return nil
 }
 
-func (yig *YigStorage) GetBucketLc(bucketName string, credential common.Credential) (lc datatype.Lc,
+func (yig *YigStorage) GetBucketLc(bucketName string, credential common.Credential, ctx context.Context) (lc datatype.Lc,
 	err error) {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return lc, err
 	}
@@ -138,8 +139,8 @@ func (yig *YigStorage) GetBucketLc(bucketName string, credential common.Credenti
 	return bucket.LC, nil
 }
 
-func (yig *YigStorage) DelBucketLc(bucketName string, credential common.Credential) error {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+func (yig *YigStorage) DelBucketLc(bucketName string, credential common.Credential, ctx context.Context) error {
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return err
 	}
@@ -154,18 +155,18 @@ func (yig *YigStorage) DelBucketLc(bucketName string, credential common.Credenti
 	if err == nil {
 		yig.MetaStorage.Cache.Remove(redis.BucketTable, bucketName)
 	}
-	err = yig.MetaStorage.RemoveBucketFromLifeCycle(*bucket)
+	err = yig.MetaStorage.RemoveBucketFromLifeCycle(*bucket, ctx)
 	if err != nil {
-		yig.Logger.Println(5, "Error Remove bucket From LC table hbase: ", err)
+		yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error Remove bucket From LC table hbase: ", err)
 		return err
 	}
 	return nil
 }
 
 func (yig *YigStorage) SetBucketCors(bucketName string, cors datatype.Cors,
-	credential common.Credential) error {
+	credential common.Credential, ctx context.Context) error {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -183,8 +184,8 @@ func (yig *YigStorage) SetBucketCors(bucketName string, cors datatype.Cors,
 	return nil
 }
 
-func (yig *YigStorage) DeleteBucketCors(bucketName string, credential common.Credential) error {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+func (yig *YigStorage) DeleteBucketCors(bucketName string, credential common.Credential, ctx context.Context) error {
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -203,9 +204,9 @@ func (yig *YigStorage) DeleteBucketCors(bucketName string, credential common.Cre
 }
 
 func (yig *YigStorage) GetBucketCors(bucketName string,
-	credential common.Credential) (cors datatype.Cors, err error) {
+	credential common.Credential, ctx context.Context) (cors datatype.Cors, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return cors, err
 	}
@@ -221,9 +222,9 @@ func (yig *YigStorage) GetBucketCors(bucketName string,
 }
 
 func (yig *YigStorage) SetBucketVersioning(bucketName string, versioning datatype.Versioning,
-	credential common.Credential) error {
+	credential common.Credential, ctx context.Context) error {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -241,10 +242,10 @@ func (yig *YigStorage) SetBucketVersioning(bucketName string, versioning datatyp
 	return nil
 }
 
-func (yig *YigStorage) GetBucketVersioning(bucketName string, credential common.Credential) (
+func (yig *YigStorage) GetBucketVersioning(bucketName string, credential common.Credential, ctx context.Context) (
 	versioning datatype.Versioning, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return versioning, err
 	}
@@ -253,10 +254,10 @@ func (yig *YigStorage) GetBucketVersioning(bucketName string, credential common.
 	return
 }
 
-func (yig *YigStorage) GetBucketAcl(bucketName string, credential common.Credential) (
+func (yig *YigStorage) GetBucketAcl(bucketName string, credential common.Credential, ctx context.Context) (
 	policy datatype.AccessControlPolicyResponse, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return policy, err
 	}
@@ -275,14 +276,14 @@ func (yig *YigStorage) GetBucketAcl(bucketName string, credential common.Credent
 }
 
 // For INTERNAL USE ONLY
-func (yig *YigStorage) GetBucket(bucketName string) (*meta.Bucket, error) {
-	return yig.MetaStorage.GetBucket(bucketName, true)
+func (yig *YigStorage) GetBucket(bucketName string, ctx context.Context) (*meta.Bucket, error) {
+	return yig.MetaStorage.GetBucket(bucketName, true, ctx)
 }
 
 func (yig *YigStorage) GetBucketInfo(bucketName string,
-	credential common.Credential) (bucket *meta.Bucket, err error) {
+	credential common.Credential, ctx context.Context) (bucket *meta.Bucket, err error) {
 
-	bucket, err = yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err = yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -302,8 +303,8 @@ func (yig *YigStorage) GetBucketInfo(bucketName string,
 	return
 }
 
-func (yig *YigStorage) SetBucketPolicy(credential common.Credential, bucketName string, bucketPolicy policy.Policy) (err error) {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+func (yig *YigStorage) SetBucketPolicy(credential common.Credential, bucketName string, bucketPolicy policy.Policy, ctx context.Context) (err error) {
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -332,8 +333,8 @@ func (yig *YigStorage) SetBucketPolicy(credential common.Credential, bucketName 
 	return nil
 }
 
-func (yig *YigStorage) GetBucketPolicy(credential common.Credential, bucketName string) (bucketPolicy policy.Policy, err error) {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+func (yig *YigStorage) GetBucketPolicy(credential common.Credential, bucketName string, ctx context.Context) (bucketPolicy policy.Policy, err error) {
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -355,8 +356,8 @@ func (yig *YigStorage) GetBucketPolicy(credential common.Credential, bucketName 
 	return
 }
 
-func (yig *YigStorage) DeleteBucketPolicy(credential common.Credential, bucketName string) error {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+func (yig *YigStorage) DeleteBucketPolicy(credential common.Credential, bucketName string, ctx context.Context) error {
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -374,13 +375,13 @@ func (yig *YigStorage) DeleteBucketPolicy(credential common.Credential, bucketNa
 	return nil
 }
 
-func (yig *YigStorage) ListBuckets(credential common.Credential) (buckets []meta.Bucket, err error) {
-	bucketNames, err := yig.MetaStorage.GetUserBuckets(credential.UserId, true)
+func (yig *YigStorage) ListBuckets(credential common.Credential, ctx context.Context) (buckets []meta.Bucket, err error) {
+	bucketNames, err := yig.MetaStorage.GetUserBuckets(credential.UserId, true, ctx)
 	if err != nil {
 		return
 	}
 	for _, bucketName := range bucketNames {
-		bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+		bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 		if err != nil {
 			return buckets, err
 		}
@@ -389,8 +390,8 @@ func (yig *YigStorage) ListBuckets(credential common.Credential) (buckets []meta
 	return
 }
 
-func (yig *YigStorage) DeleteBucket(bucketName string, credential common.Credential) (err error) {
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, false)
+func (yig *YigStorage) DeleteBucket(bucketName string, credential common.Credential, ctx context.Context) (err error) {
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, false, ctx)
 	if err != nil {
 		return err
 	}
@@ -426,9 +427,9 @@ func (yig *YigStorage) DeleteBucket(bucketName string, credential common.Credent
 	}
 
 	if bucket.LC.Rule != nil {
-		err = yig.MetaStorage.RemoveBucketFromLifeCycle(*bucket)
+		err = yig.MetaStorage.RemoveBucketFromLifeCycle(*bucket, ctx)
 		if err != nil {
-			yig.Logger.Println(5, "Error remove bucket from lifeCycle: ", err)
+			yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error remove bucket from lifeCycle: ", err)
 		}
 	}
 
@@ -436,7 +437,7 @@ func (yig *YigStorage) DeleteBucket(bucketName string, credential common.Credent
 }
 
 func (yig *YigStorage) ListObjectsInternal(bucketName string,
-	request datatype.ListObjectsRequest) (retObjects []*meta.Object, prefixes []string, truncated bool,
+	request datatype.ListObjectsRequest, ctx context.Context) (retObjects []*meta.Object, prefixes []string, truncated bool,
 	nextMarker, nextVerIdMarker string, err error) {
 
 	var marker string
@@ -457,17 +458,17 @@ func (yig *YigStorage) ListObjectsInternal(bucketName string,
 	} else { // version 1
 		marker = request.Marker
 	}
-	helper.Debugln("Prefix:", request.Prefix, "Marker:", request.Marker, "MaxKeys:",
+	helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "Prefix:", request.Prefix, "Marker:", request.Marker, "MaxKeys:",
 		request.MaxKeys, "Delimiter:", request.Delimiter, "Version:", request.Version,
 		"keyMarker:", request.KeyMarker, "versionIdMarker:", request.VersionIdMarker)
 	return yig.MetaStorage.Client.ListObjects(bucketName, marker, verIdMarker, request.Prefix, request.Delimiter, request.Versioned, request.MaxKeys)
 }
 
 func (yig *YigStorage) ListObjects(credential common.Credential, bucketName string,
-	request datatype.ListObjectsRequest) (result meta.ListObjectsInfo, err error) {
+	request datatype.ListObjectsRequest, ctx context.Context) (result meta.ListObjectsInfo, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
-	helper.Debugln("GetBucket", bucket)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "GetBucket", bucket)
 	if err != nil {
 		return
 	}
@@ -488,7 +489,7 @@ func (yig *YigStorage) ListObjects(credential common.Credential, bucketName stri
 	}
 	// TODO validate user policy and ACL
 
-	retObjects, prefixes, truncated, nextMarker, _, err := yig.ListObjectsInternal(bucketName, request)
+	retObjects, prefixes, truncated, nextMarker, _, err := yig.ListObjectsInternal(bucketName, request, ctx)
 	if truncated && len(nextMarker) != 0 {
 		result.NextMarker = nextMarker
 	}
@@ -497,7 +498,7 @@ func (yig *YigStorage) ListObjects(credential common.Credential, bucketName stri
 	}
 	objects := make([]datatype.Object, 0, len(retObjects))
 	for _, obj := range retObjects {
-		helper.Debugln("result:", obj.Name)
+		helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "result:", obj.Name)
 		object := datatype.Object{
 			LastModified: obj.LastModifiedTime.UTC().Format(meta.CREATE_TIME_LAYOUT),
 			ETag:         "\"" + obj.Etag + "\"",
@@ -539,9 +540,9 @@ func (yig *YigStorage) ListObjects(credential common.Credential, bucketName stri
 // TODO: refactor, similar to ListObjects
 // or not?
 func (yig *YigStorage) ListVersionedObjects(credential common.Credential, bucketName string,
-	request datatype.ListObjectsRequest) (result meta.VersionedListObjectsInfo, err error) {
+	request datatype.ListObjectsRequest, ctx context.Context) (result meta.VersionedListObjectsInfo, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -561,7 +562,7 @@ func (yig *YigStorage) ListVersionedObjects(credential common.Credential, bucket
 		}
 	}
 
-	retObjects, prefixes, truncated, nextMarker, nextVerIdMarker, err := yig.ListObjectsInternal(bucketName, request)
+	retObjects, prefixes, truncated, nextMarker, nextVerIdMarker, err := yig.ListObjectsInternal(bucketName, request, ctx)
 	if truncated && len(nextMarker) != 0 {
 		result.NextKeyMarker = nextMarker
 		result.NextVersionIdMarker = nextVerIdMarker

--- a/storage/multipart.go
+++ b/storage/multipart.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
@@ -28,9 +29,9 @@ const (
 )
 
 func (yig *YigStorage) ListMultipartUploads(credential common.Credential, bucketName string,
-	request datatype.ListUploadsRequest) (result datatype.ListMultipartUploadsResponse, err error) {
+	request datatype.ListUploadsRequest, ctx context.Context) (result datatype.ListMultipartUploadsResponse, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -84,9 +85,9 @@ func (yig *YigStorage) ListMultipartUploads(credential common.Credential, bucket
 
 func (yig *YigStorage) NewMultipartUpload(credential common.Credential, bucketName, objectName string,
 	metadata map[string]string, acl datatype.Acl,
-	sseRequest datatype.SseRequest, storageClass meta.StorageClass) (uploadId string, err error) {
+	sseRequest datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (uploadId string, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -105,7 +106,7 @@ func (yig *YigStorage) NewMultipartUpload(credential common.Credential, bucketNa
 		contentType = "application/octet-stream"
 	}
 
-	cephCluster, pool := yig.PickOneClusterAndPool(bucketName, objectName, -1, false)
+	cephCluster, pool := yig.PickOneClusterAndPool(bucketName, objectName, -1, false, ctx)
 	multipartMetadata := meta.MultipartMetadata{
 		InitiatorId:  credential.UserId,
 		OwnerId:      bucket.OwnerId,
@@ -143,7 +144,7 @@ func (yig *YigStorage) NewMultipartUpload(credential common.Credential, bucketNa
 
 func (yig *YigStorage) PutObjectPart(bucketName, objectName string, credential common.Credential,
 	uploadId string, partId int, size int64, data io.Reader, md5Hex string,
-	sseRequest datatype.SseRequest) (result datatype.PutObjectPartResult, err error) {
+	sseRequest datatype.SseRequest, ctx context.Context) (result datatype.PutObjectPartResult, err error) {
 	multipart, err := yig.MetaStorage.GetMultipart(bucketName, objectName, uploadId)
 	if err != nil {
 		return
@@ -225,7 +226,7 @@ func (yig *YigStorage) PutObjectPart(bucketName, objectName string, credential c
 		}
 	}
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		RecycleQueue <- maybeObjectToRecycle
 		return
@@ -272,7 +273,7 @@ func (yig *YigStorage) PutObjectPart(bucketName, objectName string, credential c
 
 func (yig *YigStorage) CopyObjectPart(bucketName, objectName, uploadId string, partId int,
 	size int64, data io.Reader, credential common.Credential,
-	sseRequest datatype.SseRequest) (result datatype.PutObjectResult, err error) {
+	sseRequest datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult, err error) {
 
 	multipart, err := yig.MetaStorage.GetMultipart(bucketName, objectName, uploadId)
 	if err != nil {
@@ -343,7 +344,7 @@ func (yig *YigStorage) CopyObjectPart(bucketName, objectName, uploadId string, p
 
 	result.Md5 = hex.EncodeToString(md5Writer.Sum(nil))
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		RecycleQueue <- maybeObjectToRecycle
 		return
@@ -392,7 +393,7 @@ func (yig *YigStorage) CopyObjectPart(bucketName, objectName, uploadId string, p
 }
 
 func (yig *YigStorage) ListObjectParts(credential common.Credential, bucketName, objectName string,
-	request datatype.ListPartsRequest) (result datatype.ListPartsResponse, err error) {
+	request datatype.ListPartsRequest, ctx context.Context) (result datatype.ListPartsResponse, err error) {
 
 	multipart, err := yig.MetaStorage.GetMultipart(bucketName, objectName, request.UploadId)
 	if err != nil {
@@ -412,7 +413,7 @@ func (yig *YigStorage) ListObjectParts(credential common.Credential, bucketName,
 		}
 	case "bucket-owner-read", "bucket-owner-full-controll":
 		var bucket *meta.Bucket
-		bucket, err = yig.MetaStorage.GetBucket(bucketName, true)
+		bucket, err = yig.MetaStorage.GetBucket(bucketName, true, ctx)
 		if err != nil {
 			return
 		}
@@ -476,9 +477,9 @@ func (yig *YigStorage) ListObjectParts(credential common.Credential, bucketName,
 }
 
 func (yig *YigStorage) AbortMultipartUpload(credential common.Credential,
-	bucketName, objectName, uploadId string) error {
+	bucketName, objectName, uploadId string, ctx context.Context) error {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return err
 	}
@@ -515,10 +516,10 @@ func (yig *YigStorage) AbortMultipartUpload(credential common.Credential,
 }
 
 func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, bucketName,
-	objectName, uploadId string, uploadedParts []meta.CompletePart) (result datatype.CompleteMultipartResult,
+	objectName, uploadId string, uploadedParts []meta.CompletePart, ctx context.Context) (result datatype.CompleteMultipartResult,
 	err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -540,16 +541,18 @@ func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, buc
 
 	md5Writer := md5.New()
 	var totalSize int64 = 0
-	helper.Logger.Println(20, "Upload parts:", uploadedParts, "uploadId:", uploadId)
+	helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]", "Upload parts:", uploadedParts, "uploadId:", uploadId)
 	for i := 0; i < len(uploadedParts); i++ {
 		if uploadedParts[i].PartNumber != i+1 {
-			helper.Logger.Println(20, "uploadedParts[i].PartNumber != i+1; i:", i, "uploadId:", uploadId)
+			helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]",
+				"uploadedParts[i].PartNumber != i+1; i:", i, "uploadId:", uploadId)
 			err = ErrInvalidPart
 			return
 		}
 		part, ok := multipart.Parts[i+1]
 		if !ok {
-			helper.Logger.Println(20, "multipart.Parts[i+1] does not exist; i:", i, "uploadId:", uploadId)
+			helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]",
+				"multipart.Parts[i+1] does not exist; i:", i, "uploadId:", uploadId)
 			err = ErrInvalidPart
 			return
 		}
@@ -562,7 +565,7 @@ func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, buc
 			return
 		}
 		if part.Etag != uploadedParts[i].ETag {
-			helper.Logger.Println(20, "part.Etag != uploadedParts[i].ETag;",
+			helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]", "part.Etag != uploadedParts[i].ETag;",
 				"i:", i, "Etag:", part.Etag, "reqEtag:", uploadedParts[i].ETag, "uploadId:", uploadId)
 			err = ErrInvalidPart
 			return
@@ -570,7 +573,8 @@ func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, buc
 		var etagBytes []byte
 		etagBytes, err = hex.DecodeString(part.Etag)
 		if err != nil {
-			helper.Logger.Println(20, "hex.DecodeString(part.Etag) err;", "uploadId:", uploadId)
+			helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]",
+				"hex.DecodeString(part.Etag) err;", "uploadId:", uploadId)
 			err = ErrInvalidPart
 			return
 		}
@@ -607,7 +611,7 @@ func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, buc
 	}
 
 	var nullVerNum uint64
-	nullVerNum, err = yig.checkOldObject(bucketName, objectName, bucket.Versioning)
+	nullVerNum, err = yig.checkOldObject(bucketName, objectName, bucket.Versioning, ctx)
 	if err != nil {
 		return
 	}

--- a/storage/multipart.go
+++ b/storage/multipart.go
@@ -28,10 +28,10 @@ const (
 	MAX_PART_NUMBER = 10000
 )
 
-func (yig *YigStorage) ListMultipartUploads(credential common.Credential, bucketName string,
-	request datatype.ListUploadsRequest, ctx context.Context) (result datatype.ListMultipartUploadsResponse, err error) {
+func (yig *YigStorage) ListMultipartUploads(ctx context.Context, credential common.Credential, bucketName string,
+	request datatype.ListUploadsRequest) (result datatype.ListMultipartUploadsResponse, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	bucket, err := yig.MetaStorage.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		return
 	}
@@ -83,11 +83,11 @@ func (yig *YigStorage) ListMultipartUploads(credential common.Credential, bucket
 	return
 }
 
-func (yig *YigStorage) NewMultipartUpload(credential common.Credential, bucketName, objectName string,
+func (yig *YigStorage) NewMultipartUpload(ctx context.Context, credential common.Credential, bucketName, objectName string,
 	metadata map[string]string, acl datatype.Acl,
-	sseRequest datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (uploadId string, err error) {
+	sseRequest datatype.SseRequest, storageClass meta.StorageClass) (uploadId string, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	bucket, err := yig.MetaStorage.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		return
 	}
@@ -106,7 +106,7 @@ func (yig *YigStorage) NewMultipartUpload(credential common.Credential, bucketNa
 		contentType = "application/octet-stream"
 	}
 
-	cephCluster, pool := yig.PickOneClusterAndPool(bucketName, objectName, -1, false, ctx)
+	cephCluster, pool := yig.PickOneClusterAndPool(ctx, bucketName, objectName, -1, false)
 	multipartMetadata := meta.MultipartMetadata{
 		InitiatorId:  credential.UserId,
 		OwnerId:      bucket.OwnerId,
@@ -142,9 +142,9 @@ func (yig *YigStorage) NewMultipartUpload(credential common.Credential, bucketNa
 	return
 }
 
-func (yig *YigStorage) PutObjectPart(bucketName, objectName string, credential common.Credential,
+func (yig *YigStorage) PutObjectPart(ctx context.Context, bucketName, objectName string, credential common.Credential,
 	uploadId string, partId int, size int64, data io.Reader, md5Hex string,
-	sseRequest datatype.SseRequest, ctx context.Context) (result datatype.PutObjectPartResult, err error) {
+	sseRequest datatype.SseRequest) (result datatype.PutObjectPartResult, err error) {
 	multipart, err := yig.MetaStorage.GetMultipart(bucketName, objectName, uploadId)
 	if err != nil {
 		return
@@ -226,7 +226,7 @@ func (yig *YigStorage) PutObjectPart(bucketName, objectName string, credential c
 		}
 	}
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	bucket, err := yig.MetaStorage.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		RecycleQueue <- maybeObjectToRecycle
 		return
@@ -271,9 +271,9 @@ func (yig *YigStorage) PutObjectPart(bucketName, objectName string, credential c
 	return result, nil
 }
 
-func (yig *YigStorage) CopyObjectPart(bucketName, objectName, uploadId string, partId int,
+func (yig *YigStorage) CopyObjectPart(ctx context.Context, bucketName, objectName, uploadId string, partId int,
 	size int64, data io.Reader, credential common.Credential,
-	sseRequest datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult, err error) {
+	sseRequest datatype.SseRequest) (result datatype.PutObjectResult, err error) {
 
 	multipart, err := yig.MetaStorage.GetMultipart(bucketName, objectName, uploadId)
 	if err != nil {
@@ -344,7 +344,7 @@ func (yig *YigStorage) CopyObjectPart(bucketName, objectName, uploadId string, p
 
 	result.Md5 = hex.EncodeToString(md5Writer.Sum(nil))
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	bucket, err := yig.MetaStorage.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		RecycleQueue <- maybeObjectToRecycle
 		return
@@ -392,8 +392,8 @@ func (yig *YigStorage) CopyObjectPart(bucketName, objectName, uploadId string, p
 	return result, nil
 }
 
-func (yig *YigStorage) ListObjectParts(credential common.Credential, bucketName, objectName string,
-	request datatype.ListPartsRequest, ctx context.Context) (result datatype.ListPartsResponse, err error) {
+func (yig *YigStorage) ListObjectParts(ctx context.Context, credential common.Credential, bucketName, objectName string,
+	request datatype.ListPartsRequest) (result datatype.ListPartsResponse, err error) {
 
 	multipart, err := yig.MetaStorage.GetMultipart(bucketName, objectName, request.UploadId)
 	if err != nil {
@@ -413,7 +413,7 @@ func (yig *YigStorage) ListObjectParts(credential common.Credential, bucketName,
 		}
 	case "bucket-owner-read", "bucket-owner-full-controll":
 		var bucket *meta.Bucket
-		bucket, err = yig.MetaStorage.GetBucket(bucketName, true, ctx)
+		bucket, err = yig.MetaStorage.GetBucket(ctx, bucketName, true)
 		if err != nil {
 			return
 		}
@@ -476,10 +476,10 @@ func (yig *YigStorage) ListObjectParts(credential common.Credential, bucketName,
 	return
 }
 
-func (yig *YigStorage) AbortMultipartUpload(credential common.Credential,
-	bucketName, objectName, uploadId string, ctx context.Context) error {
+func (yig *YigStorage) AbortMultipartUpload(ctx context.Context, credential common.Credential,
+	bucketName, objectName, uploadId string) error {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	bucket, err := yig.MetaStorage.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		return err
 	}
@@ -515,11 +515,11 @@ func (yig *YigStorage) AbortMultipartUpload(credential common.Credential,
 	return nil
 }
 
-func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, bucketName,
-	objectName, uploadId string, uploadedParts []meta.CompletePart, ctx context.Context) (result datatype.CompleteMultipartResult,
+func (yig *YigStorage) CompleteMultipartUpload(ctx context.Context, credential common.Credential, bucketName,
+	objectName, uploadId string, uploadedParts []meta.CompletePart) (result datatype.CompleteMultipartResult,
 	err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
+	bucket, err := yig.MetaStorage.GetBucket(ctx, bucketName, true)
 	if err != nil {
 		return
 	}
@@ -611,7 +611,7 @@ func (yig *YigStorage) CompleteMultipartUpload(credential common.Credential, buc
 	}
 
 	var nullVerNum uint64
-	nullVerNum, err = yig.checkOldObject(bucketName, objectName, bucket.Versioning, ctx)
+	nullVerNum, err = yig.checkOldObject(ctx, bucketName, objectName, bucket.Versioning)
 	if err != nil {
 		return
 	}

--- a/storage/object.go
+++ b/storage/object.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"time"
 
+	"context"
 	"path"
 	"sync"
 
@@ -25,7 +26,7 @@ import (
 var latestQueryTime [2]time.Time // 0 is for SMALL_FILE_POOLNAME, 1 is for BIG_FILE_POOLNAME
 const CLUSTER_MAX_USED_SPACE_PERCENT = 85
 
-func (yig *YigStorage) PickOneClusterAndPool(bucket string, object string, size int64, isAppend bool) (cluster *CephStorage,
+func (yig *YigStorage) PickOneClusterAndPool(bucket string, object string, size int64, isAppend bool, ctx context.Context) (cluster *CephStorage,
 	poolName string) {
 
 	var idx int
@@ -51,7 +52,7 @@ func (yig *YigStorage) PickOneClusterAndPool(bucket string, object string, size 
 	var totalWeight int
 	clusterWeights := make(map[string]int, len(yig.DataStorage))
 	for fsid, _ := range yig.DataStorage {
-		cluster, err := yig.MetaStorage.GetCluster(fsid, poolName)
+		cluster, err := yig.MetaStorage.GetCluster(fsid, poolName, ctx)
 		if err != nil {
 			helper.Debugln("Error getting cluster: ", err)
 			continue
@@ -74,7 +75,7 @@ func (yig *YigStorage) PickOneClusterAndPool(bucket string, object string, size 
 		clusterWeights[fsid] = cluster.Weight
 	}
 	if len(clusterWeights) == 0 || totalWeight == 0 {
-		helper.Logger.Println(5, "Error picking cluster from table cluster in DB! Use first cluster in config to write.")
+		helper.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Error picking cluster from table cluster in DB! Use first cluster in config to write.")
 		for _, c := range yig.DataStorage {
 			cluster = c
 			break
@@ -152,7 +153,7 @@ func generateTransPartObjectFunc(cephCluster *CephStorage, object *meta.Object, 
 }
 
 func (yig *YigStorage) GetObject(object *meta.Object, startOffset int64,
-	length int64, writer io.Writer, sseRequest datatype.SseRequest) (err error) {
+	length int64, writer io.Writer, sseRequest datatype.SseRequest, ctx context.Context) (err error) {
 	var encryptionKey []byte
 	if object.SseType == crypto.S3.String() {
 		if yig.KMS == nil {
@@ -184,7 +185,7 @@ func (yig *YigStorage) GetObject(object *meta.Object, startOffset int64,
 			transPartObjectWriter := generateTransPartObjectFunc(cephCluster, object, nil, startOffset, length)
 
 			return yig.DataCache.WriteFromCache(object, startOffset, length, writer,
-				transPartObjectWriter, transWholeObjectWriter)
+				transPartObjectWriter, transWholeObjectWriter, ctx)
 		}
 
 		// encrypted object
@@ -193,7 +194,7 @@ func (yig *YigStorage) GetObject(object *meta.Object, startOffset int64,
 				startOffset, length)
 		}
 		reader, err := yig.DataCache.GetAlignedReader(object, startOffset, length, normalAligenedGet,
-			transWholeObjectWriter)
+			transWholeObjectWriter, ctx)
 		if err != nil {
 			return err
 		}
@@ -255,7 +256,7 @@ func (yig *YigStorage) GetObject(object *meta.Object, startOffset int64,
 			// encrypted object
 			err = copyEncryptedPart(object.Pool, p, cephCluster, readOffset, readLength, encryptionKey, writer)
 			if err != nil {
-				helper.Debugln("Multipart uploaded object write error:", err)
+				helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "Multipart uploaded object write error:", err)
 			}
 		}
 	}
@@ -284,17 +285,17 @@ func copyEncryptedPart(pool string, part *meta.Part, cephCluster *CephStorage, r
 }
 
 func (yig *YigStorage) GetObjectInfo(bucketName string, objectName string,
-	version string, credential common.Credential) (object *meta.Object, err error) {
+	version string, credential common.Credential, ctx context.Context) (object *meta.Object, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
 
 	if version == "" {
-		object, err = yig.MetaStorage.GetObject(bucketName, objectName, true)
+		object, err = yig.MetaStorage.GetObject(bucketName, objectName, true, ctx)
 	} else {
-		object, err = yig.getObjWithVersion(bucketName, objectName, version)
+		object, err = yig.getObjWithVersion(bucketName, objectName, version, ctx)
 	}
 	if err != nil {
 		return
@@ -326,18 +327,18 @@ func (yig *YigStorage) GetObjectInfo(bucketName string, objectName string,
 }
 
 func (yig *YigStorage) GetObjectAcl(bucketName string, objectName string,
-	version string, credential common.Credential) (policy datatype.AccessControlPolicyResponse, err error) {
+	version string, credential common.Credential, ctx context.Context) (policy datatype.AccessControlPolicyResponse, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
 
 	var object *meta.Object
 	if version == "" {
-		object, err = yig.MetaStorage.GetObject(bucketName, objectName, true)
+		object, err = yig.MetaStorage.GetObject(bucketName, objectName, true, ctx)
 	} else {
-		object, err = yig.getObjWithVersion(bucketName, objectName, version)
+		object, err = yig.getObjWithVersion(bucketName, objectName, version, ctx)
 	}
 	if err != nil {
 		return
@@ -371,17 +372,17 @@ func (yig *YigStorage) GetObjectAcl(bucketName string, objectName string,
 }
 
 func (yig *YigStorage) SetObjectAcl(bucketName string, objectName string, version string,
-	policy datatype.AccessControlPolicy, acl datatype.Acl, credential common.Credential) error {
+	policy datatype.AccessControlPolicy, acl datatype.Acl, credential common.Credential, ctx context.Context) error {
 
 	if acl.CannedAcl == "" {
-		newCannedAcl, err := datatype.GetCannedAclFromPolicy(policy)
+		newCannedAcl, err := datatype.GetCannedAclFromPolicy(policy, ctx)
 		if err != nil {
 			return err
 		}
 		acl = newCannedAcl
 	}
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return err
 	}
@@ -397,9 +398,9 @@ func (yig *YigStorage) SetObjectAcl(bucketName string, objectName string, versio
 	} // TODO policy and fancy ACL
 	var object *meta.Object
 	if version == "" {
-		object, err = yig.MetaStorage.GetObject(bucketName, objectName, false)
+		object, err = yig.MetaStorage.GetObject(bucketName, objectName, false, ctx)
 	} else {
-		object, err = yig.getObjWithVersion(bucketName, objectName, version)
+		object, err = yig.getObjWithVersion(bucketName, objectName, version, ctx)
 	}
 	if err != nil {
 		return err
@@ -442,17 +443,17 @@ func (yig *YigStorage) SetObjectAcl(bucketName string, objectName string, versio
 // Encryptor is enabled when user set SSE headers
 func (yig *YigStorage) PutObject(bucketName string, objectName string, credential common.Credential,
 	size int64, data io.Reader, metadata map[string]string, acl datatype.Acl,
-	sseRequest datatype.SseRequest, storageClass meta.StorageClass) (result datatype.PutObjectResult, err error) {
+	sseRequest datatype.SseRequest, storageClass meta.StorageClass, ctx context.Context) (result datatype.PutObjectResult, err error) {
 
 	encryptionKey, cipherKey, err := yig.encryptionKeyFromSseRequest(sseRequest, bucketName, objectName)
-	helper.Debugln("get encryptionKey:", encryptionKey, "cipherKey:", cipherKey, "err:", err)
+	helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "enter PutObject get encryptionKey:", encryptionKey, "cipherKey:", cipherKey, "err:", err)
 	if err != nil {
 		return
 	}
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
-		helper.Debugln("get bucket", bucket, "err:", err)
+		helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "get bucket", bucket, "err:", err)
 		return
 	}
 
@@ -475,7 +476,7 @@ func (yig *YigStorage) PutObject(bucketName string, objectName string, credentia
 		limitedDataReader = data
 	}
 
-	cephCluster, poolName := yig.PickOneClusterAndPool(bucketName, objectName, size, false)
+	cephCluster, poolName := yig.PickOneClusterAndPool(bucketName, objectName, size, false, ctx)
 	if cephCluster == nil {
 		return result, ErrInternalError
 	}
@@ -509,7 +510,7 @@ func (yig *YigStorage) PutObject(bucketName string, objectName string, credentia
 	}
 	if bytesWritten < size {
 		RecycleQueue <- maybeObjectToRecycle
-		helper.Logger.Printf(2, "failed to write objects, already written(%d), total size(%d)", bytesWritten, size)
+		helper.Logger.Printf(2, "[", helper.RequestIdFromContext(ctx), "]", "failed to write objects, already written(%d), total size(%d)", bytesWritten, size)
 		return result, ErrIncompleteBody
 	}
 
@@ -557,7 +558,7 @@ func (yig *YigStorage) PutObject(bucketName string, objectName string, credentia
 
 	result.LastModified = object.LastModifiedTime
 	var nullVerNum uint64
-	nullVerNum, err = yig.checkOldObject(bucketName, objectName, bucket.Versioning)
+	nullVerNum, err = yig.checkOldObject(bucketName, objectName, bucket.Versioning, ctx)
 	if err != nil {
 		RecycleQueue <- maybeObjectToRecycle
 		return
@@ -595,10 +596,10 @@ func (yig *YigStorage) PutObject(bucketName string, objectName string, credentia
 //TODO: Append Support Encryption
 func (yig *YigStorage) AppendObject(bucketName string, objectName string, credential common.Credential,
 	offset uint64, size int64, data io.Reader, metadata map[string]string, acl datatype.Acl,
-	sseRequest datatype.SseRequest, storageClass meta.StorageClass, objInfo *meta.Object) (result datatype.AppendObjectResult, err error) {
+	sseRequest datatype.SseRequest, storageClass meta.StorageClass, objInfo *meta.Object, ctx context.Context) (result datatype.AppendObjectResult, err error) {
 
 	encryptionKey, cipherKey, err := yig.encryptionKeyFromSseRequest(sseRequest, bucketName, objectName)
-	helper.Logger.Println(10, "get encryptionKey:", encryptionKey, "cipherKey:", cipherKey, "err:", err)
+	helper.Logger.Println(10, "[", helper.RequestIdFromContext(ctx), "]", "get encryptionKey:", encryptionKey, "cipherKey:", cipherKey, "err:", err)
 	if err != nil {
 		return
 	}
@@ -631,12 +632,12 @@ func (yig *YigStorage) AppendObject(bucketName string, objectName string, creden
 		initializationVector = objInfo.InitializationVector
 		objSize = objInfo.Size
 		storageClass = objInfo.StorageClass
-		helper.Logger.Println(20, "request append oid:", oid, "iv:", initializationVector, "size:", objSize)
+		helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]", "request append oid:", oid, "iv:", initializationVector, "size:", objSize)
 	} else {
 		// New appendable object
-		cephCluster, poolName = yig.PickOneClusterAndPool(bucketName, objectName, size, true)
+		cephCluster, poolName = yig.PickOneClusterAndPool(bucketName, objectName, size, true, ctx)
 		if cephCluster == nil || poolName != BIG_FILE_POOLNAME {
-			helper.Debugln("PickOneClusterAndPool error")
+			helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "PickOneClusterAndPool error")
 			return result, ErrInternalError
 		}
 		// Mapping a shorter name for the object
@@ -647,7 +648,7 @@ func (yig *YigStorage) AppendObject(bucketName string, objectName string, creden
 				return
 			}
 		}
-		helper.Logger.Println(20, "request first append oid:", oid, "iv:", initializationVector, "size:", objSize)
+		helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]", "request first append oid:", oid, "iv:", initializationVector, "size:", objSize)
 	}
 
 	dataReader := io.TeeReader(limitedDataReader, md5Writer)
@@ -658,7 +659,7 @@ func (yig *YigStorage) AppendObject(bucketName string, objectName string, creden
 	}
 	bytesWritten, err := cephCluster.Append(poolName, oid, storageReader, offset, isObjectExist(objInfo))
 	if err != nil {
-		helper.Debugln("cephCluster.Append err:", err, poolName, oid, offset)
+		helper.Debugln("[", helper.RequestIdFromContext(ctx), "]", "cephCluster.Append err:", err, poolName, oid, offset)
 		return
 	}
 
@@ -707,7 +708,7 @@ func (yig *YigStorage) AppendObject(bucketName string, objectName string, creden
 
 	result.LastModified = object.LastModifiedTime
 	result.NextPosition = object.Size
-	helper.Logger.Println(20, "Append info.", "bucket:", bucketName, "objName:", objectName, "oid:", oid,
+	helper.Logger.Println(20, "[", helper.RequestIdFromContext(ctx), "]", "Append info.", "bucket:", bucketName, "objName:", objectName, "oid:", oid,
 		"objSize:", object.Size, "bytesWritten:", bytesWritten, "storageClass:", storageClass)
 	err = yig.MetaStorage.AppendObject(object, isObjectExist(objInfo))
 	if err != nil {
@@ -721,9 +722,9 @@ func (yig *YigStorage) AppendObject(bucketName string, objectName string, creden
 	return result, nil
 }
 
-func (yig *YigStorage) UpdateObjectAttrs(targetObject *meta.Object, credential common.Credential) (result datatype.PutObjectResult, err error) {
+func (yig *YigStorage) UpdateObjectAttrs(targetObject *meta.Object, credential common.Credential, ctx context.Context) (result datatype.PutObjectResult, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(targetObject.BucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(targetObject.BucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -738,7 +739,7 @@ func (yig *YigStorage) UpdateObjectAttrs(targetObject *meta.Object, credential c
 
 	err = yig.MetaStorage.UpdateObjectAttrs(targetObject)
 	if err != nil {
-		yig.Logger.Println(5, "Update Object Attrs, sql fails")
+		yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Update Object Attrs, sql fails")
 		return result, ErrInternalError
 	}
 	result.LastModified = targetObject.LastModifiedTime
@@ -752,7 +753,7 @@ func (yig *YigStorage) UpdateObjectAttrs(targetObject *meta.Object, credential c
 }
 
 func (yig *YigStorage) CopyObject(targetObject *meta.Object, source io.Reader, credential common.Credential,
-	sseRequest datatype.SseRequest) (result datatype.PutObjectResult, err error) {
+	sseRequest datatype.SseRequest, ctx context.Context) (result datatype.PutObjectResult, err error) {
 
 	var oid string
 	var maybeObjectToRecycle objectToRecycle
@@ -762,7 +763,7 @@ func (yig *YigStorage) CopyObject(targetObject *meta.Object, source io.Reader, c
 		return
 	}
 
-	bucket, err := yig.MetaStorage.GetBucket(targetObject.BucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(targetObject.BucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -781,7 +782,7 @@ func (yig *YigStorage) CopyObject(targetObject *meta.Object, source io.Reader, c
 	limitedDataReader = io.LimitReader(source, targetObject.Size)
 
 	cephCluster, poolName := yig.PickOneClusterAndPool(targetObject.BucketName,
-		targetObject.Name, targetObject.Size, false)
+		targetObject.Name, targetObject.Size, false, ctx)
 
 	if len(targetObject.Parts) != 0 {
 		var targetParts map[int]*meta.Part = make(map[int]*meta.Part, len(targetObject.Parts))
@@ -900,7 +901,7 @@ func (yig *YigStorage) CopyObject(targetObject *meta.Object, source io.Reader, c
 	result.LastModified = targetObject.LastModifiedTime
 
 	var nullVerNum uint64
-	nullVerNum, err = yig.checkOldObject(targetObject.BucketName, targetObject.Name, bucket.Versioning)
+	nullVerNum, err = yig.checkOldObject(targetObject.BucketName, targetObject.Name, bucket.Versioning, ctx)
 	if err != nil {
 		RecycleQueue <- maybeObjectToRecycle
 		return
@@ -945,7 +946,7 @@ func (yig *YigStorage) removeByObject(object *meta.Object, objMap *meta.ObjMap) 
 	return nil
 }
 
-func (yig *YigStorage) getObjWithVersion(bucketName, objectName, version string) (object *meta.Object, err error) {
+func (yig *YigStorage) getObjWithVersion(bucketName, objectName, version string, ctx context.Context) (object *meta.Object, err error) {
 	if version == "null" {
 		objMap, err := yig.MetaStorage.GetObjectMap(bucketName, objectName)
 		if err != nil {
@@ -953,7 +954,7 @@ func (yig *YigStorage) getObjWithVersion(bucketName, objectName, version string)
 		}
 		version = objMap.NullVerId
 	}
-	return yig.MetaStorage.GetObjectVersion(bucketName, objectName, version, true)
+	return yig.MetaStorage.GetObjectVersion(bucketName, objectName, version, true, ctx)
 
 }
 
@@ -975,7 +976,7 @@ func (yig *YigStorage) removeAllObjectsEntryByName(bucketName, objectName string
 	return
 }
 
-func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string) (version uint64, err error) {
+func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string, ctx context.Context) (version uint64, err error) {
 
 	if versioning == "Disabled" {
 		err = yig.removeAllObjectsEntryByName(bucketName, objectName)
@@ -996,7 +997,7 @@ func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string)
 		}
 		var object *meta.Object
 		if objMapExist {
-			object, err = yig.MetaStorage.GetObjectVersion(bucketName, objectName, objMap.NullVerId, false)
+			object, err = yig.MetaStorage.GetObjectVersion(bucketName, objectName, objMap.NullVerId, false, ctx)
 			if err == ErrNoSuchKey {
 				err = nil
 				objectExist = false
@@ -1004,7 +1005,7 @@ func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string)
 				return 0, err
 			}
 		} else {
-			object, err = yig.MetaStorage.GetObject(bucketName, objectName, false)
+			object, err = yig.MetaStorage.GetObject(bucketName, objectName, false, ctx)
 			if err == ErrNoSuchKey {
 				err = nil
 				objectExist = false
@@ -1013,6 +1014,7 @@ func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string)
 			}
 		}
 
+		reqId := helper.RequestIdFromContext(ctx)
 		if versioning == "Enabled" {
 			if !objMapExist && objectExist && object.NullVersion {
 				/*decrypted, err := meta.Decrypt(object.GetVersionNumber())
@@ -1025,14 +1027,14 @@ func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string)
 				}*/
 				version, err = object.GetVersionNumber()
 				if err != nil {
-					helper.Debugln("-----------old object version:", err)
+					helper.Debugln("[", reqId, "]", "-----------old object version:", err)
 					return 0, err
 				}
-				helper.Debugln("-----------old object version:", version)
+				helper.Debugln("[", reqId, "]", "-----------old object version:", version)
 				return
 			}
 		} else {
-			helper.Debugln("object.NullVersion:", object.NullVersion)
+			helper.Debugln("[", reqId, "]", "object.NullVersion:", object.NullVersion)
 			if objectExist && object.NullVersion {
 				err = yig.MetaStorage.DeleteObject(object, object.DeleteMarker, nil)
 				if err != nil {
@@ -1046,8 +1048,8 @@ func (yig *YigStorage) checkOldObject(bucketName, objectName, versioning string)
 	return 0, errors.New("No Such versioning status!")
 }
 
-func (yig *YigStorage) removeObjectVersion(bucketName, objectName, version string) error {
-	object, err := yig.getObjWithVersion(bucketName, objectName, version)
+func (yig *YigStorage) removeObjectVersion(bucketName, objectName, version string, ctx context.Context) error {
+	object, err := yig.getObjWithVersion(bucketName, objectName, version, ctx)
 	if err == ErrNoSuchKey {
 		return nil
 	}
@@ -1106,9 +1108,9 @@ func (yig *YigStorage) addDeleteMarker(bucket meta.Bucket, objectName string,
 //
 // See http://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
 func (yig *YigStorage) DeleteObject(bucketName string, objectName string, version string,
-	credential common.Credential) (result datatype.DeleteObjectResult, err error) {
+	credential common.Credential, ctx context.Context) (result datatype.DeleteObjectResult, err error) {
 
-	bucket, err := yig.MetaStorage.GetBucket(bucketName, true)
+	bucket, err := yig.MetaStorage.GetBucket(bucketName, true, ctx)
 	if err != nil {
 		return
 	}
@@ -1138,7 +1140,7 @@ func (yig *YigStorage) DeleteObject(bucketName string, objectName string, versio
 			}
 			result.DeleteMarker = true
 		} else {
-			err = yig.removeObjectVersion(bucketName, objectName, version)
+			err = yig.removeObjectVersion(bucketName, objectName, version, ctx)
 			if err != nil {
 				return
 			}
@@ -1146,7 +1148,7 @@ func (yig *YigStorage) DeleteObject(bucketName string, objectName string, versio
 		}
 	case "Suspended":
 		if version == "" {
-			err = yig.removeObjectVersion(bucketName, objectName, "null")
+			err = yig.removeObjectVersion(bucketName, objectName, "null", ctx)
 			if err != nil {
 				return
 			}
@@ -1156,14 +1158,14 @@ func (yig *YigStorage) DeleteObject(bucketName string, objectName string, versio
 			}
 			result.DeleteMarker = true
 		} else {
-			err = yig.removeObjectVersion(bucketName, objectName, version)
+			err = yig.removeObjectVersion(bucketName, objectName, version, ctx)
 			if err != nil {
 				return
 			}
 			result.VersionId = version
 		}
 	default:
-		yig.Logger.Println(5, "Invalid bucket versioning: ", bucketName)
+		yig.Logger.Println(5, "[", helper.RequestIdFromContext(ctx), "]", "Invalid bucket versioning: ", bucketName)
 		return result, ErrInternalError
 	}
 


### PR DESCRIPTION
1. Add requestId in log messages, to facilitate grep all the related info within one request as follows.
2. Add log level. You may add log with ike "helper.Logger.Println(**LOG_ERROR**, ...)"
3. Verified with s3cmd in most touched commands.

[yig]2019/07/25 03:29:53 **[ G2S5210RQJIFT6V9 ]** GenerateContextHandler. RequestId: G2S5210RQJIFT6V9 BucketName: test-log-bucket1 ObjectName: 
[yig]2019/07/25 03:29:53 [ G2S5210RQJIFT6V9 ] enabledSimpleMetaCache Get. table: 1 key: test-log-bucket1
[yig]2019/07/25 03:29:53 [ G2S5210RQJIFT6V9 ] GetBucket CacheMiss. bucket: test-log-bucket1
[yig]2019/07/25 03:29:54 [ G2S5210RQJIFT6V9 ] STARTING GET s3.test.com:8080/test-log-bucket1/?location RequestID:G2S5210RQJIFT6V9
[yig]2019/07/25 03:29:54 [ G2S5210RQJIFT6V9 ] ServeHTTP test-log-bucket1 
[yig]2019/07/25 03:29:54 [ G2S5210RQJIFT6V9 ] enabledSimpleMetaCache Get. table: 1 key: test-log-bucket1
[yig]2019/07/25 03:29:54 [ G2S5210RQJIFT6V9 ] COMPLETED GET s3.test.com:8080/test-log-bucket1/?location RequestID:G2S5210RQJIFT6V9
