### PR TITLE
Mock ceph access and benchmark

### DIFF
--- a/ceph/cluster.go
+++ b/ceph/cluster.go
@@ -112,7 +112,7 @@ func pending_has_completed(p *list.List) bool {
 		return false
 	}
 	e := p.Front()
-	c := e.Value.(*rados.AioCompletion)
+	c := e.Value.(AioCompletion)
 	ret := c.IsComplete()
 	if ret == 0 {
 		return false
@@ -125,7 +125,7 @@ func wait_pending_front(p *list.List) int {
 	/* remove AioCompletion from list */
 	e := p.Front()
 	p.Remove(e)
-	c := e.Value.(*rados.AioCompletion)
+	c := e.Value.(AioCompletion)
 	c.WaitForComplete()
 	ret := c.GetReturnValue()
 	c.Release()

--- a/ceph/cluster_test.go
+++ b/ceph/cluster_test.go
@@ -1,0 +1,94 @@
+package ceph_test
+
+import (
+	"bytes"
+	"github.com/journeymidnight/yig/backend"
+	"github.com/journeymidnight/yig/ceph"
+	"github.com/journeymidnight/yig/helper"
+	"testing"
+	"time"
+)
+
+func SetupMockCeph() ceph.CephCluster {
+	helper.CONFIG.UploadMinChunkSize = 512 << 10
+	helper.CONFIG.UploadMaxChunkSize = 8 << 20
+
+	striper := MockStriperPool{
+		FixedReadOverhead:  3 * time.Millisecond,
+		FixedWriteOverhead: 5 * time.Millisecond,
+	}
+	pool := MockPool{
+		MockStriper:        striper,
+		FixedReadOverhead:  3 * time.Millisecond,
+		FixedWriteOverhead: 5 * time.Millisecond,
+	}
+	conn := MockRadosConn{
+		MockPool: pool,
+	}
+	cluster := ceph.CephCluster{
+		Name:       "benchmark",
+		Conn:       conn,
+		InstanceId: 0,
+	}
+	return cluster
+}
+
+func BenchmarkCephCluster_Put(b *testing.B) {
+	mockData120K := make([]byte, 120<<10)
+	for i := 0; i < len(mockData120K); i++ {
+		mockData120K[i] = uint8(i)
+	}
+	mockData10M := make([]byte, 10<<20)
+	for i := 0; i < len(mockData10M); i++ {
+		mockData10M[i] = uint8(i)
+	}
+	mockData30M := make([]byte, 30<<20)
+	for i := 0; i < len(mockData30M); i++ {
+		mockData30M[i] = uint8(i)
+	}
+	mockData100M := make([]byte, 100<<20)
+	for i := 0; i < len(mockData100M); i++ {
+		mockData100M[i] = uint8(i)
+	}
+	cluster := SetupMockCeph()
+	b.Run("Put small pool 120K", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			reader := bytes.NewReader(mockData120K)
+			oid, size, err := cluster.Put(backend.SMALL_FILE_POOLNAME, reader)
+			if err != nil {
+				b.Error("Put error:", err)
+			}
+			b.Log("oid:", oid, "size:", size)
+		}
+	})
+	b.Run("Put big pool 10M", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			reader := bytes.NewReader(mockData10M)
+			oid, size, err := cluster.Put(backend.BIG_FILE_POOLNAME, reader)
+			if err != nil {
+				b.Error("Put error:", err)
+			}
+			b.Log("oid:", oid, "size:", size)
+		}
+	})
+	b.Run("Put big pool 30M", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			reader := bytes.NewReader(mockData30M)
+			oid, size, err := cluster.Put(backend.BIG_FILE_POOLNAME, reader)
+			if err != nil {
+				b.Error("Put error:", err)
+			}
+			b.Log("oid:", oid, "size:", size)
+		}
+	})
+	b.Run("Put big pool 100M", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			reader := bytes.NewReader(mockData100M)
+			oid, size, err := cluster.Put(backend.BIG_FILE_POOLNAME, reader)
+			if err != nil {
+				b.Error("Put error:", err)
+			}
+			b.Log("oid:", oid, "size:", size)
+		}
+	})
+}

--- a/ceph/rados.go
+++ b/ceph/rados.go
@@ -1,0 +1,79 @@
+package ceph
+
+import "github.com/journeymidnight/radoshttpd/rados"
+
+// Interfaces for underlying rados lib, mainly to ease testing/mocking
+
+type RadosConn interface {
+	OpenPool(name string) (Pool, error)
+	GetClusterStats() (rados.ClusterStat, error)
+	Shutdown()
+}
+
+type Pool interface {
+	Write(oid string, data []byte, offset uint64) error
+	Read(oid string, data []byte, offset uint64) (int, error)
+	Delete(oid string) error
+	Truncate(oid string, size uint64) error
+	Destroy()
+	CreateStriper() (StriperPool, error)
+	WriteSmallObject(oid string, data []byte) error
+}
+
+type StriperPool interface {
+	Read(oid string, data []byte, offset uint64) (int, error)
+	Write(oid string, data []byte, offset uint64) (int, error)
+	WriteAIO(oid string, data []byte, offset uint64) (AioCompletion, error)
+	Delete(oid string) error
+	Destroy()
+	SetLayoutStripeUnit(uint uint) int
+	SetLayoutStripeCount(count uint) int
+	SetLayoutObjectSize(size uint) int
+}
+
+type AioCompletion interface {
+	WaitForComplete()
+	Release()
+	IsComplete() int
+	GetReturnValue() int
+}
+
+type radosConn struct {
+	*rados.Conn
+}
+
+func (c radosConn) OpenPool(name string) (Pool, error) {
+	p, err := c.Conn.OpenPool(name)
+	if err != nil {
+		return nil, err
+	}
+	return pool{p}, nil
+}
+
+type pool struct {
+	*rados.Pool
+}
+
+func (p pool) CreateStriper() (StriperPool, error) {
+	s, err := p.Pool.CreateStriper()
+	if err != nil {
+		return nil, err
+	}
+	return striperPool{&s}, nil
+}
+
+type striperPool struct {
+	*rados.StriperPool
+}
+
+func (sp striperPool) WriteAIO(oid string,
+	data []byte, offset uint64) (AioCompletion, error) {
+
+	aio := &rados.AioCompletion{}
+	err := aio.Create()
+	if err != nil {
+		return nil, err
+	}
+	_, err = sp.StriperPool.WriteAIO(aio, oid, data, offset)
+	return aio, err
+}

--- a/ceph/rados_test.go
+++ b/ceph/rados_test.go
@@ -1,0 +1,144 @@
+package ceph_test
+
+import (
+	"github.com/journeymidnight/radoshttpd/rados"
+	"github.com/journeymidnight/yig/ceph"
+	"time"
+)
+
+// Mocked rados connection for testing
+
+// Simulate total processing time as:
+// fixed processing time + processing time relative to data size
+
+type MockRadosConn struct {
+	MockPool MockPool
+}
+
+func (c MockRadosConn) OpenPool(name string) (ceph.Pool, error) {
+	return c.MockPool, nil
+}
+
+func (c MockRadosConn) GetClusterStats() (rados.ClusterStat, error) {
+	return rados.ClusterStat{}, nil
+}
+
+func (c MockRadosConn) Shutdown() {
+	return
+}
+
+type MockPool struct {
+	MockStriper        MockStriperPool
+	FixedReadOverhead  time.Duration
+	FixedWriteOverhead time.Duration
+}
+
+func (p MockPool) Write(oid string, data []byte, offset uint64) error {
+	processingTime := p.FixedWriteOverhead + time.Duration(len(data))
+	time.Sleep(processingTime)
+	return nil
+}
+
+func (p MockPool) Read(oid string, data []byte, offset uint64) (int, error) {
+	processingTime := p.FixedReadOverhead + time.Duration(len(data))
+	time.Sleep(processingTime)
+	return len(data), nil
+}
+
+func (p MockPool) Delete(oid string) error {
+	time.Sleep(p.FixedWriteOverhead)
+	return nil
+}
+
+func (p MockPool) Truncate(oid string, size uint64) error {
+	time.Sleep(p.FixedWriteOverhead)
+	return nil
+}
+
+func (p MockPool) Destroy() {
+	return
+}
+
+func (p MockPool) CreateStriper() (ceph.StriperPool, error) {
+	return p.MockStriper, nil
+}
+
+func (p MockPool) WriteSmallObject(oid string, data []byte) error {
+	processingTime := p.FixedWriteOverhead + time.Duration(len(data))
+	time.Sleep(processingTime)
+	return nil
+}
+
+type MockStriperPool struct {
+	FixedReadOverhead  time.Duration
+	FixedWriteOverhead time.Duration
+}
+
+func (sp MockStriperPool) Read(oid string, data []byte, offset uint64) (int, error) {
+	processingTime := sp.FixedReadOverhead + time.Duration(len(data))
+	time.Sleep(processingTime)
+	return len(data), nil
+}
+
+func (sp MockStriperPool) Write(oid string, data []byte, offset uint64) (int, error) {
+	processingTime := sp.FixedWriteOverhead + time.Duration(len(data))
+	time.Sleep(processingTime)
+	return len(data), nil
+}
+
+func (sp MockStriperPool) WriteAIO(oid string, data []byte, offset uint64) (ceph.AioCompletion, error) {
+	return MockAioCompletion{
+		CreatedAt:      time.Now(),
+		ProcessingTime: sp.FixedWriteOverhead + time.Duration(len(data)),
+	}, nil
+}
+
+func (sp MockStriperPool) Delete(oid string) error {
+	time.Sleep(sp.FixedWriteOverhead)
+	return nil
+}
+
+func (sp MockStriperPool) Destroy() {
+	return
+}
+
+func (sp MockStriperPool) SetLayoutStripeUnit(uint uint) int {
+	return 0
+}
+
+func (sp MockStriperPool) SetLayoutStripeCount(count uint) int {
+	return 0
+}
+
+func (sp MockStriperPool) SetLayoutObjectSize(size uint) int {
+	return 0
+}
+
+type MockAioCompletion struct {
+	CreatedAt      time.Time
+	ProcessingTime time.Duration
+}
+
+func (aio MockAioCompletion) WaitForComplete() {
+	finishTime := aio.CreatedAt.Add(aio.ProcessingTime)
+	if time.Now().After(finishTime) {
+		return
+	}
+	time.Sleep(finishTime.Sub(time.Now()))
+}
+
+func (aio MockAioCompletion) Release() {
+	return
+}
+
+func (aio MockAioCompletion) IsComplete() int {
+	finishTime := aio.CreatedAt.Add(aio.ProcessingTime)
+	if time.Now().After(finishTime) {
+		return 1 // true
+	}
+	return 0 // false
+}
+
+func (aio MockAioCompletion) GetReturnValue() int {
+	return 0
+}


### PR DESCRIPTION
- Mock ceph access and modify the upper layer to use defined interfaces
- A benchmark test to test PUT time.

Example output:
```
$ go test -bench .
goos: linux
goarch: amd64
pkg: github.com/journeymidnight/yig/ceph
BenchmarkCephCluster_Put/Put_small_pool_120K-40         	     300	   5640262 ns/op
--- BENCH: BenchmarkCephCluster_Put/Put_small_pool_120K-40
    cluster_test.go:61: oid: 0:1 size: 122880
    cluster_test.go:61: oid: 0:2 size: 122880
    cluster_test.go:61: oid: 0:3 size: 122880
    cluster_test.go:61: oid: 0:4 size: 122880
    cluster_test.go:61: oid: 0:5 size: 122880
    cluster_test.go:61: oid: 0:6 size: 122880
    cluster_test.go:61: oid: 0:7 size: 122880
    cluster_test.go:61: oid: 0:8 size: 122880
    cluster_test.go:61: oid: 0:9 size: 122880
    cluster_test.go:61: oid: 0:10 size: 122880
	... [output truncated]
BenchmarkCephCluster_Put/Put_big_pool_10M-40            	     100	  15402088 ns/op
--- BENCH: BenchmarkCephCluster_Put/Put_big_pool_10M-40
    cluster_test.go:71: oid: 0:402 size: 10485760
    cluster_test.go:71: oid: 0:403 size: 10485760
    cluster_test.go:71: oid: 0:404 size: 10485760
    cluster_test.go:71: oid: 0:405 size: 10485760
    cluster_test.go:71: oid: 0:406 size: 10485760
    cluster_test.go:71: oid: 0:407 size: 10485760
    cluster_test.go:71: oid: 0:408 size: 10485760
    cluster_test.go:71: oid: 0:409 size: 10485760
    cluster_test.go:71: oid: 0:410 size: 10485760
    cluster_test.go:71: oid: 0:411 size: 10485760
	... [output truncated]
BenchmarkCephCluster_Put/Put_big_pool_30M-40            	      50	  28498774 ns/op
--- BENCH: BenchmarkCephCluster_Put/Put_big_pool_30M-40
    cluster_test.go:81: oid: 0:503 size: 31457280
    cluster_test.go:81: oid: 0:504 size: 31457280
    cluster_test.go:81: oid: 0:505 size: 31457280
    cluster_test.go:81: oid: 0:506 size: 31457280
    cluster_test.go:81: oid: 0:507 size: 31457280
    cluster_test.go:81: oid: 0:508 size: 31457280
    cluster_test.go:81: oid: 0:509 size: 31457280
    cluster_test.go:81: oid: 0:510 size: 31457280
    cluster_test.go:81: oid: 0:511 size: 31457280
    cluster_test.go:81: oid: 0:512 size: 31457280
	... [output truncated]
BenchmarkCephCluster_Put/Put_big_pool_100M-40           	      20	  65160821 ns/op
--- BENCH: BenchmarkCephCluster_Put/Put_big_pool_100M-40
    cluster_test.go:91: oid: 0:554 size: 104857600
    cluster_test.go:91: oid: 0:555 size: 104857600
    cluster_test.go:91: oid: 0:556 size: 104857600
    cluster_test.go:91: oid: 0:557 size: 104857600
    cluster_test.go:91: oid: 0:558 size: 104857600
    cluster_test.go:91: oid: 0:559 size: 104857600
    cluster_test.go:91: oid: 0:560 size: 104857600
    cluster_test.go:91: oid: 0:561 size: 104857600
    cluster_test.go:91: oid: 0:562 size: 104857600
    cluster_test.go:91: oid: 0:563 size: 104857600
	... [output truncated]
PASS
ok  	github.com/journeymidnight/yig/ceph	6.909s
```