### PR TITLE
Fix bug that the object with size of 1M cannot be deleted completely

### DIFF
--- a/ceph/cluster.go
+++ b/ceph/cluster.go
@@ -553,6 +553,9 @@ func (cluster *CephCluster) Remove(poolname string, oid string) error {
 		return errors.New("Bad ioctx")
 	}
 	defer striper.Destroy()
+	// if we do not set our custom layout, rados will infer all objects filename from default layout setting, 
+	// and some sub objects will not be deleted
+	setStripeLayout(striper)
 
 	return striper.Delete(oid)
 }


### PR DESCRIPTION
 If we do not set our custom layout, rados will infer all objects filename from default layout setting, and some sub objects will not be deleted