### PR TITLE
Fix list bucket objects

### DIFF
--- a/meta/client/tidbclient/bucket.go
+++ b/meta/client/tidbclient/bucket.go
@@ -258,6 +258,10 @@ func (t *TidbClient) ListObjects(bucketName, marker, verIdMarker, prefix, delimi
 			var o *Object
 			Strver := strconv.FormatUint(version, 10)
 			o, err = t.GetObject(bucketname, name, Strver)
+			if err == ErrNoSuchKey {
+				// it's possible the object is already deleted
+				continue
+			}
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Xinwei hits a bug when mounting s3fs(which calls GET bucket) and deleting objects at the same time.
