### PR TITLE
Bugfix: When put a object with the same name of a appendable object

### DIFF
--- a/meta/client/client.go
+++ b/meta/client/client.go
@@ -22,7 +22,7 @@ type Client interface {
 	UpdateFreezerObject(object *Object, tx Tx) (err error)
 	UpdateAppendObject(object *Object) error
 	MigrateObject(object *Object) error
-	RemoveHotObject(object *Object) error
+	RemoveHotObject(object *Object, tx Tx) error
 	RenameObject(object *Object, sourceObject string) (err error)
 
 	ReplaceObjectMetas(object *Object, tx Tx) (err error)

--- a/meta/client/tidbclient/object.go
+++ b/meta/client/tidbclient/object.go
@@ -367,10 +367,15 @@ func (t *TidbClient) MigrateObject(object *Object) (err error) {
 	return
 }
 
-func (t *TidbClient) RemoveHotObject(object *Object) (err error) {
-	sql, args := object.GetRemoveHotSql()
-	_, err = t.Client.Exec(sql, args...)
-
+func (t *TidbClient) RemoveHotObject(object *Object, tx Tx) (err error) {
+	if tx == nil {
+		sql, args := object.GetRemoveHotSql()
+		_, err = t.Client.Exec(sql, args...)
+	} else {
+		txn := tx.(*sql.Tx)
+		sql, args := object.GetRemoveHotSql()
+		_, err = txn.Exec(sql, args...)
+	}
 	return
 }
 

--- a/meta/object.go
+++ b/meta/object.go
@@ -83,6 +83,12 @@ func (m *Meta) PutObject(reqCtx RequestContext, object *Object, multipart *Multi
 			if err != nil {
 				return err
 			}
+			if reqCtx.ObjectInfo.Type == ObjectTypeAppendable && reqCtx.ObjectInfo.Pool == backend.SMALL_FILE_POOLNAME {
+				err = m.Client.RemoveHotObject(reqCtx.ObjectInfo, tx)
+				if err != nil {
+					return err
+				}
+			}
 			return m.Client.UpdateObject(object, multipart, updateUsage, tx)
 		} else {
 			return m.Client.PutObject(object, multipart, updateUsage)
@@ -197,7 +203,7 @@ func (m *Meta) DeleteObject(object *Object) (err error) {
 
 	//delete object meta in hotobjects table
 	if object.Type == ObjectTypeAppendable && object.Pool == backend.SMALL_FILE_POOLNAME {
-		err = m.Client.RemoveHotObject(object)
+		err = m.Client.RemoveHotObject(object, tx)
 		if err != nil {
 			return err
 		}
@@ -271,6 +277,6 @@ func (m *Meta) MigrateObject(object *Object) error {
 	return m.Client.MigrateObject(object)
 }
 
-func (m *Meta) RemoveHotObject(object *Object) error {
-	return m.Client.RemoveHotObject(object)
+func (m *Meta) RemoveHotObject(object *Object, tx Tx) error {
+	return m.Client.RemoveHotObject(object, tx)
 }

--- a/tools/migrate.go
+++ b/tools/migrate.go
@@ -61,7 +61,7 @@ func checkAndDoMigrate(index int) {
 		sourceObject, err = yigs[index].MetaStorage.GetObject(object.BucketName, object.Name, object.VersionId, true)
 		if err != nil {
 			if err == ErrNoSuchKey {
-				yigs[index].MetaStorage.RemoveHotObject(&object)
+				yigs[index].MetaStorage.RemoveHotObject(&object, nil)
 				goto release
 			}
 			goto quit


### PR DESCRIPTION
which is placed in rabbit pool temporarily, metadata of the appendable
object should be removed from hotobjects