### PR TITLE
Reduce memory usage

### DIFF
--- a/helper/string.go
+++ b/helper/string.go
@@ -21,39 +21,35 @@ func StringInSlice(s string, ss []string) bool {
 	return false
 }
 
-func CopiedBytes(source []byte) (destination []byte) {
-	destination = make([]byte, len(source), len(source))
-	copy(destination, source)
-	return destination
+// compare 2 strings case-insensitively, only handle ASCII
+func CaseInsensitiveEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		aChar := a[i]
+		bChar := b[i]
+		if aChar == bChar {
+			continue
+		}
+		if 'A' <= aChar && aChar <= 'Z' && aChar+'a'-'A' == bChar {
+			continue
+		}
+		if 'A' <= bChar && bChar <= 'Z' && bChar+'a'-'A' == aChar {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
-func UnicodeIndex(str, substr string) int {
-	result := strings.Index(str, substr)
-	if result >= 0 {
-		prefix := []byte(str)[0:result]
-		rs := []rune(string(prefix))
-		result = len(rs)
-	}
-	return result
-}
+func StringInSliceCustomCompare(s string, ss []string,
+	compare func(string, string) bool) bool {
 
-func SubString(str string, begin, length int) (substr string) {
-	rs := []rune(str)
-	lth := len(rs)
-	if begin < 0 {
-		begin = 0
+	for _, x := range ss {
+		if compare(x, s) {
+			return true
+		}
 	}
-	if begin >= lth {
-		begin = lth
-	}
-	var end int
-	if length == -1 {
-		end = lth
-	} else {
-		end = begin + length
-	}
-	if end > lth {
-		end = lth
-	}
-	return string(rs[begin:end])
+	return false
 }

--- a/helper/string_test.go
+++ b/helper/string_test.go
@@ -1,0 +1,24 @@
+package helper
+
+import "testing"
+
+func TestCaseInsensitiveEqual(t *testing.T) {
+	As := []string{
+		"X-Amz-Hehe",
+		"AbcdefgHijklmn",
+		"x-amz-content-sha256",
+	}
+	Bs := []string{
+		"x-amz-hehe",
+		"abcdefghijklmn",
+		"X-Amz-Content-Sha256",
+	}
+	for i := 0; i < len(As); i++ {
+		if CaseInsensitiveEqual(As[i], Bs[i]) == false {
+			t.Error("False:", As[i], Bs[i])
+		}
+		if CaseInsensitiveEqual(Bs[i], As[i]) == false {
+			t.Error("False:", Bs[i], As[i])
+		}
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -70,8 +70,8 @@ func getCaller(skipCallDepth int) string {
 	if !ok {
 		return ""
 	}
-	fileParts := strings.Split(fullPath, "/")
-	file := fileParts[len(fileParts)-1]
+	i := strings.LastIndex(fullPath, "/")
+	file := fullPath[i+1:]
 	return fmt.Sprintf("%s:%d", file, line)
 }
 

--- a/signature/v4-parser.go
+++ b/signature/v4-parser.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/journeymidnight/yig/api/datatype"
 	. "github.com/journeymidnight/yig/error"
+	"github.com/journeymidnight/yig/helper"
 	"github.com/journeymidnight/yig/iam"
 )
 
@@ -121,9 +122,9 @@ func parseSignedHeadersContent(signedHeader string, headers http.Header,
 	//  Content-Type(required if present in request, not needed in presigned auth)
 	//  X-Amz-* headers
 	for k := range headers {
-		lower := strings.ToLower(k)
-		if strings.HasPrefix(lower, "x-amz-") {
-			if !headerSigned(lower, signedHeaders) {
+		if strings.HasPrefix(k, "X-Amz-") {
+			if !helper.StringInSliceCustomCompare(k, signedHeaders,
+				helper.CaseInsensitiveEqual) {
 				return nil, ErrMissingRequiredSignedHeader
 			}
 		}


### PR DESCRIPTION
by Fuda's profile, these functions consume large amount of memory
- the `strings.ToLower()` in `parseSignedHeadersContent`
- the `strings.Split()` in `getCaller`