### PR TITLE
Add prefix constrain for list bucket objects

### DIFF
--- a/meta/client/tidbclient/bucket.go
+++ b/meta/client/tidbclient/bucket.go
@@ -179,12 +179,44 @@ func (t *TidbClient) ListObjects(bucketName, marker, verIdMarker, prefix, delimi
 		var loopcount int
 		var sqltext string
 		var rows *sql.Rows
-		if marker == "" {
-			sqltext = "select bucketname,name,version,nullversion,deletemarker from objects where bucketName=? order by bucketname,name,version limit ?;"
-			rows, err = t.Client.Query(sqltext, bucketName, maxKeys)
-		} else {
-			sqltext = "select bucketname,name,version,nullversion,deletemarker from objects where bucketName=? and name >=? order by bucketname,name,version limit ?,?;"
-			rows, err = t.Client.Query(sqltext, bucketName, marker, objectNum[marker], objectNum[marker]+maxKeys)
+		if prefix == "" {
+			if marker == "" {
+				sqltext = `select bucketname,name,version,nullversion,deletemarker 
+					from objects 
+					where bucketName=? 
+					order by bucketname,name,version 
+					limit ?`
+				rows, err = t.Client.Query(sqltext, bucketName, maxKeys)
+			} else {
+				sqltext = `select bucketname,name,version,nullversion,deletemarker 
+					from objects 
+					where bucketName=? 
+					and name >=? 
+					order by bucketname,name,version 
+					limit ?,?`
+				rows, err = t.Client.Query(sqltext, bucketName, marker, objectNum[marker], objectNum[marker]+maxKeys)
+			}
+		} else { // prefix not empty
+			prefixPattern := prefix + "%"
+			if marker == "" {
+				sqltext = `select bucketname,name,version,nullversion,deletemarker 
+					from objects 
+					where bucketName=? 
+					and name like ?
+					order by bucketname,name,version 
+					limit ?`
+				rows, err = t.Client.Query(sqltext, bucketName, prefixPattern, maxKeys)
+			} else {
+				sqltext = `select bucketname,name,version,nullversion,deletemarker 
+					from objects 
+					where bucketName=? 
+					and name >=? 
+					and name like ?
+					order by bucketname,name,version 
+					limit ?,?`
+				rows, err = t.Client.Query(sqltext, bucketName, marker, prefixPattern,
+					objectNum[marker], objectNum[marker]+maxKeys)
+			}
 		}
 		if err != nil {
 			return


### PR DESCRIPTION
e.g.
for a bucket:
```
/a/1
/a/2
/a/3
...
/a/100
/b/1
/b/2
/b/3
...
/b/100
/b/101
/b/102
...
/b/999
/b/1000
/c/1
/c/2
/c/3
...
/c/999
/c/1000
```
When listing objects with prefix = "/a" and maxKeys = 1000, current implementation would read the WHOLE bucket.