### PR TITLE
Graceful shutdown and log-rotate

### DIFF
--- a/admin-server.go
+++ b/admin-server.go
@@ -164,7 +164,7 @@ func startAdminServer(c *adminServerConfig) {
 	adminServer = c
 	serverAddress := c.Address
 	host, port, _ := net.SplitHostPort(serverAddress)
-	// If port empty, default to port '80'
+	// If port empty, default to port 9000
 	if port == "" {
 		port = "9000"
 	}
@@ -188,10 +188,10 @@ func startAdminServer(c *adminServerConfig) {
 	printListenIPs(false, hosts, port)
 
 	go func() {
-		var err error
-		// Configure TLS if certs are available.
-		err = adminServer.ListenAndServe()
-		helper.PanicOnError(err, "API server error.")
+		listener, err := helper.ReusePortListener(host, port)
+		helper.PanicOnError(err, "Admin server error.")
+		err = adminServer.Serve(listener)
+		helper.PanicOnError(err, "Admin server error.")
 	}()
 }
 

--- a/error/api-errors.go
+++ b/error/api-errors.go
@@ -118,6 +118,7 @@ const (
 	ErrObjectNotAppendable
 	ErrPositionNotEqualToLength
 	ErrMetadataHeader
+	ErrMaintenance
 	// Add new error codes here.
 
 	// SSE-S3 related API errors
@@ -827,6 +828,11 @@ var ErrorCodeResponse = map[ApiErrorCode]ApiErrorStruct{
 		AwsErrorCode:   "CreateRestoreObjectError",
 		Description:    "Create object thaw operation failed",
 		HttpStatusCode: http.StatusInternalServerError,
+	},
+	ErrMaintenance: {
+		AwsErrorCode: "ServiceTemporaryMaintenance",
+		Description: "Temporary maintenance, please retry your request",
+		HttpStatusCode: http.StatusServiceUnavailable,
 	},
 }
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -1,7 +1,10 @@
 package helper
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -109,8 +112,8 @@ func MarshalTOMLConfig() error {
 	CONFIG.Region = c.Region
 	CONFIG.Plugins = c.Plugins
 	CONFIG.PiggybackUpdateUsage = c.PiggybackUpdateUsage
-	CONFIG.LogPath = c.LogPath
-	CONFIG.AccessLogPath = c.AccessLogPath
+	CONFIG.LogPath = logFilePathWithPid(c.LogPath)
+	CONFIG.AccessLogPath = logFilePathWithPid(c.AccessLogPath)
 	CONFIG.AccessLogFormat = c.AccessLogFormat
 	CONFIG.PanicLogPath = c.PanicLogPath
 	CONFIG.PidFile = c.PidFile
@@ -169,4 +172,13 @@ func MarshalTOMLConfig() error {
 	CONFIG.UploadMaxChunkSize = Ternary(c.UploadMaxChunkSize < CONFIG.UploadMinChunkSize || c.UploadMaxChunkSize > MAX_BUFEER_SIZE, MAX_BUFEER_SIZE, c.UploadMaxChunkSize).(int64)
 
 	return nil
+}
+
+// Convert from "/var/log/yig/yig.log" to something like "/var/log/yig/49106.yig.log"
+// Only support UNIX style path
+func logFilePathWithPid(rawPath string) string {
+	pid := os.Getpid()
+	parts := strings.Split(rawPath, "/")
+	parts[len(parts)-1] = fmt.Sprintf("%d.%s", pid, parts[len(parts)-1])
+	return strings.Join(parts, "/")
 }

--- a/log/log.go
+++ b/log/log.go
@@ -133,8 +133,7 @@ func (l Logger) ReopenLogFile() {
 	}
 	newFile, err := os.OpenFile(l.filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		l.Error("ReopenLogFile:", l.filePath, err)
-		return
+		panic(fmt.Sprintln("ReopenLogFile:", l.filePath, err))
 	}
 	oldFile := l.out
 	l.out = newFile

--- a/log/log.go
+++ b/log/log.go
@@ -31,6 +31,7 @@ func ParseLevel(levelString string) Level {
 }
 
 type Logger struct {
+	filePath  string // the underlying log file path
 	out       io.WriteCloser
 	level     Level
 	logger    *log.Logger
@@ -44,7 +45,9 @@ func NewFileLogger(path string, logLevel Level) Logger {
 	if err != nil {
 		panic("Failed to open log file " + path)
 	}
-	return NewLogger(f, logLevel)
+	l := NewLogger(f, logLevel)
+	l.filePath = path
+	return l
 }
 
 func NewLogger(out io.WriteCloser, logLevel Level) Logger {
@@ -122,4 +125,18 @@ func (l Logger) Println(args ...interface{}) {
 
 func (l Logger) Close() error {
 	return l.out.Close()
+}
+
+func (l Logger) ReopenLogFile() {
+	if len(l.filePath) == 0 {
+		return
+	}
+	newFile, err := os.OpenFile(l.filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		l.Error("ReopenLogFile:", l.filePath, err)
+		return
+	}
+	oldFile := l.out
+	l.out = newFile
+	_ = oldFile.Close()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -135,7 +135,9 @@ func (l Logger) ReopenLogFile() {
 	if err != nil {
 		panic(fmt.Sprintln("ReopenLogFile:", l.filePath, err))
 	}
+	newLogger := log.New(newFile, "", logFlags)
 	oldFile := l.out
 	l.out = newFile
+	l.logger = newLogger
 	_ = oldFile.Close()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -127,7 +127,7 @@ func (l Logger) Close() error {
 	return l.out.Close()
 }
 
-func (l Logger) ReopenLogFile() {
+func (l *Logger) ReopenLogFile() {
 	if len(l.filePath) == 0 {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/journeymidnight/yig/compression"
 	"github.com/journeymidnight/yig/crypto"
 	"math/rand"
@@ -36,14 +37,17 @@ func main() {
 
 	helper.SetupConfig()
 
+	pid := os.Getpid()
 	// yig log
 	logLevel := log.ParseLevel(helper.CONFIG.LogLevel)
-	helper.Logger = log.NewFileLogger(helper.CONFIG.LogPath, logLevel)
+	helper.Logger = log.NewFileLogger(
+		fmt.Sprintf("%s.%d", helper.CONFIG.LogPath, pid), logLevel)
 	defer helper.Logger.Close()
 	helper.Logger.Info("YIG conf:", helper.CONFIG)
 	helper.Logger.Info("YIG instance ID:", helper.CONFIG.InstanceId)
 	// access log
-	helper.AccessLogger = log.NewFileLogger(helper.CONFIG.AccessLogPath, log.InfoLevel)
+	helper.AccessLogger = log.NewFileLogger(
+		fmt.Sprintf("%s.%d", helper.CONFIG.AccessLogPath, pid), log.InfoLevel)
 	defer helper.AccessLogger.Close()
 
 	if helper.CONFIG.MetaCacheType > 0 || helper.CONFIG.EnableDataCache {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/journeymidnight/yig/compression"
 	"github.com/journeymidnight/yig/crypto"
 	"math/rand"
@@ -28,17 +27,14 @@ func main() {
 
 	helper.SetupConfig()
 
-	pid := os.Getpid()
 	// yig log
 	logLevel := log.ParseLevel(helper.CONFIG.LogLevel)
-	helper.Logger = log.NewFileLogger(
-		fmt.Sprintf("%d.%s", pid, helper.CONFIG.LogPath), logLevel)
+	helper.Logger = log.NewFileLogger(helper.CONFIG.LogPath, logLevel)
 	defer helper.Logger.Close()
 	helper.Logger.Info("YIG conf:", helper.CONFIG)
 	helper.Logger.Info("YIG instance ID:", helper.CONFIG.InstanceId)
 	// access log
-	helper.AccessLogger = log.NewFileLogger(
-		fmt.Sprintf("%d.%s", pid, helper.CONFIG.AccessLogPath), log.InfoLevel)
+	helper.AccessLogger = log.NewFileLogger(helper.CONFIG.AccessLogPath, log.InfoLevel)
 	defer helper.AccessLogger.Close()
 
 	if helper.CONFIG.MetaCacheType > 0 || helper.CONFIG.EnableDataCache {

--- a/package/access.logrotate
+++ b/package/access.logrotate
@@ -1,5 +1,5 @@
 compress
-/var/log/yig/access.log {
+/var/log/yig/access.log* {
     daily
     rotate 7
     missingok

--- a/package/access.logrotate
+++ b/package/access.logrotate
@@ -1,9 +1,11 @@
 compress
-/var/log/yig/access.log* {
+/var/log/yig/*.access.log {
     daily
     rotate 7
     missingok
     compress
     minsize 100k
-    copytruncate
+	postrotate
+		ps -ef|grep yig$|awk '{print $2}'|xargs kill -SIGUSR2
+	endscript
 }

--- a/package/yig.logrotate
+++ b/package/yig.logrotate
@@ -1,9 +1,11 @@
 compress
-/var/log/yig/yig.log* {
+/var/log/yig/*.yig.log {
     daily
     rotate 7
     missingok
     compress
     minsize 100k
-    copytruncate
+    postrotate
+    	ps -ef|grep yig$|awk '{print $2}'|xargs kill -SIGUSR1
+    endscript
 }

--- a/package/yig.logrotate
+++ b/package/yig.logrotate
@@ -1,5 +1,5 @@
 compress
-/var/log/yig/yig.log {
+/var/log/yig/yig.log* {
     daily
     rotate 7
     missingok


### PR DESCRIPTION
- use SO_REUSEPORT and SO_REUSEADDR to allow multiple yig running at the same time
- also adjust log file names
- memorize concurrent request number, when stopping, wait until the number reduced to 0
- use signal to trigger reopening log file for log rotate

I'll make it more graceful after kernel version is updated.